### PR TITLE
Add request character encoding for search servlet

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiClientServlet.java
+++ b/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiClientServlet.java
@@ -388,6 +388,7 @@ public abstract class AbstractSenseiClientServlet extends ZookeeperConfigurableS
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
+	req.setCharacterEncoding("UTF-8");
     resp.setContentType("application/json; charset=utf-8");
     resp.setCharacterEncoding("UTF-8");
 


### PR DESCRIPTION
Trying to solve the wrong encoding for utf-8 characters when calling the api servlet.
