### PR TITLE
Update URL to scala-tools.org snapshot repository.

### DIFF
--- a/sensei-parent/pom.xml
+++ b/sensei-parent/pom.xml
@@ -132,7 +132,7 @@
 	    </repository>
 	    <repository>
 	      <id>Scala Tools Repository</id>
-	      <url>http://nexus.scala-tools.org/content/repositories/snapshots/</url>
+	      <url>http://scala-tools.org/repo-snapshots</url>
 	    </repository>
       <repository>
         <id>labs-consol-release</id>


### PR DESCRIPTION
Scala-tools.org changed their URL to the maven repo. Updated to right one.
