### PR TITLE
Use _zoieSystemMap.keySet instead as the _dataCollectorMap is not populated yet

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/indexing/DefaultStreamingIndexingManager.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/DefaultStreamingIndexingManager.java
@@ -151,7 +151,7 @@ public class DefaultStreamingIndexingManager implements SenseiIndexingManager<JS
 		StreamDataProvider<JSONObject> dataProvider = null;
     if (_gateway!=null){
 		  try{
-		    dataProvider = _gateway.buildDataProvider(_senseiSchema, _oldestSinceKey, pluginRegistry,_shardingStrategy,_dataCollectorMap.keySet());
+		    dataProvider = _gateway.buildDataProvider(_senseiSchema, _oldestSinceKey, pluginRegistry,_shardingStrategy,_zoieSystemMap.keySet());
         long maxEventsPerMin = _myconfig.getLong(EVTS_PER_MIN,40000);
         dataProvider.setMaxEventsPerMinute(maxEventsPerMin);
         int batchSize = _myconfig.getInt(BATCH_SIZE,1);


### PR DESCRIPTION
The bug causes the SenseiGateway implementation not able to know the set of partitions it is going to host.
