### PR TITLE
Allow metrics related threads and mbeans cleanup on sensei server shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target
 *.iml
 *.ipr
 *.iws
+.idea

--- a/sensei-core/src/main/java/com/senseidb/indexing/TimeBasedIndexSelector.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/TimeBasedIndexSelector.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.IOException;
 import java.util.Map;
 
@@ -30,7 +31,6 @@ import com.senseidb.metrics.MetricsConstants;
 import com.senseidb.plugin.SenseiPlugin;
 import com.senseidb.plugin.SenseiPluginRegistry;
 import com.senseidb.search.req.SenseiRequest;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
 
@@ -38,16 +38,10 @@ public class TimeBasedIndexSelector implements SenseiIndexPruner, SenseiPlugin {
 
   private static final String TIME_FACET_NAME = "facetName";
   private String facetName;
-  private static Counter processedReadersCount;
-  private static Counter filteredReadersCount;
-  static{
-    // register jmx monitoring for timers
-      MetricName processedReadersMetric = new MetricName(MetricsConstants.Domain, "timeBasedIndexPruner","processedReaderCount");
-      processedReadersCount = Metrics.newCounter(processedReadersMetric);
-      MetricName filteredReadersMetric = new MetricName(MetricsConstants.Domain,"timeBasedIndexPruner","filteredReaderCount");
-      filteredReadersCount = Metrics.newCounter(filteredReadersMetric);
-  
-  }
+
+  private Counter processedReadersCount;
+  private Counter filteredReadersCount;
+
   private IndexReaderSelector defaultReaderSelector = new IndexReaderSelector() {
     @Override
     public boolean isSelected(BoboIndexReader reader) throws IOException {
@@ -77,11 +71,11 @@ public class TimeBasedIndexSelector implements SenseiIndexPruner, SenseiPlugin {
         }
         long[] elements = ((TermLongList)facetDataCache.valArray).getElements();
         if (elements.length < 2) {
-          filteredReadersCount.inc();          
+          filteredReadersCount.inc();
           return false;
         }
         if (elements[1] > end || elements[elements.length - 1] < start) {
-          filteredReadersCount.inc();          
+          filteredReadersCount.inc();
           return false;
         }                
         return true;
@@ -121,14 +115,15 @@ public class TimeBasedIndexSelector implements SenseiIndexPruner, SenseiPlugin {
 
   @Override
   public void start() {
-    // TODO Auto-generated method stub
-    
+    // register jmx monitoring for timers
+    MetricName processedReadersMetric = new MetricName(MetricsConstants.Domain, "timeBasedIndexPruner","processedReaderCount");
+    processedReadersCount = MetricFactory.newCounter(processedReadersMetric);
+    MetricName filteredReadersMetric = new MetricName(MetricsConstants.Domain,"timeBasedIndexPruner","filteredReaderCount");
+    filteredReadersCount = MetricFactory.newCounter(filteredReadersMetric);
   }
 
   @Override
   public void stop() {
-    // TODO Auto-generated method stub
-    
   }
 
 }

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityManager.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityManager.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,7 +57,6 @@ import com.senseidb.plugin.SenseiPluginRegistry;
 import com.senseidb.search.node.SenseiCore;
 import com.senseidb.search.plugin.PluggableSearchEngine;
 import com.senseidb.search.plugin.PluggableSearchEngineManager;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
 
@@ -77,13 +77,10 @@ public class CompositeActivityManager implements PluggableSearchEngine {
     private SenseiCore senseiCore;
     private PurgeUnusedActivitiesJob purgeUnusedActivitiesJob;
     private Map<String, Set<String>> columnToFacetMapping = new HashMap<String, Set<String>>();
-    private static Counter recoveredIndexInBoboFacetDataCache;
-    private static Counter facetMappingMismatch;
+    private Counter recoveredIndexInBoboFacetDataCache;
+    private Counter facetMappingMismatch;
     private ActivityPersistenceFactory activityPersistenceFactory;
-    static {
-      recoveredIndexInBoboFacetDataCache = Metrics.newCounter(new MetricName(CompositeActivityManager.class, "recoveredIndexInBoboFacetDataCache"));
-      facetMappingMismatch =  Metrics.newCounter(new MetricName(CompositeActivityManager.class, "facetMappingMismatch"));
-    }
+
     public CompositeActivityManager(ActivityPersistenceFactory activityPersistenceFactory) {      
       this.activityPersistenceFactory = activityPersistenceFactory;
       
@@ -344,6 +341,10 @@ public class CompositeActivityManager implements PluggableSearchEngine {
  
 
   public void start(SenseiCore senseiCore) {
+    recoveredIndexInBoboFacetDataCache = MetricFactory.newCounter(new MetricName(CompositeActivityManager.class, "recoveredIndexInBoboFacetDataCache"));
+    facetMappingMismatch =  MetricFactory.newCounter(new MetricName(CompositeActivityManager.class,
+                                                                    "facetMappingMismatch"));
+
     this.senseiCore = senseiCore;
     Set<IndexReaderFactory<ZoieIndexReader<BoboIndexReader>>> zoieSystems = new HashSet<IndexReaderFactory<ZoieIndexReader<BoboIndexReader>>>();
     for (int partition : senseiCore.getPartitions()) {

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityStorage.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityStorage.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -32,7 +33,6 @@ import org.springframework.util.Assert;
 
 import com.senseidb.indexing.activity.primitives.ActivityPrimitivesStorage;
 import com.senseidb.metrics.MetricsConstants;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
 
@@ -45,11 +45,14 @@ public class CompositeActivityStorage {
   private MappedByteBuffer buffer;
   private long fileLength; 
   private boolean activateMemoryMappedBuffers = false;
-  private Timer timer;
+  private final Timer timer;
 
   public CompositeActivityStorage(String indexDir) {   
     this.indexDir = indexDir;
-    timer = Metrics.newTimer(new MetricName(MetricsConstants.Domain,"timer","initCompositeActivities-time" ,"CompositeActivityStorage"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    timer = MetricFactory.newTimer(new MetricName(MetricsConstants.Domain,
+                                                  "timer",
+                                                  "initCompositeActivities-time",
+                                                  "CompositeActivityStorage"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
  
   }
 

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
@@ -79,19 +79,13 @@ public class CompositeActivityValues {
   private volatile boolean closed;
   private ActivityConfig activityConfig;
   
-  protected final Counter reclaimedDocumentsCounter;
-  protected final Counter currentDocumentsCounter;
-  protected final Counter deletedDocumentsCounter;
-  protected final Counter insertedDocumentsCounter;
-  protected final Counter totalUpdatesCounter;
+  protected Counter reclaimedDocumentsCounter;
+  protected Counter currentDocumentsCounter;
+  protected Counter deletedDocumentsCounter;
+  protected Counter insertedDocumentsCounter;
+  protected Counter totalUpdatesCounter;
 
   CompositeActivityValues() {
-    reclaimedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class,
-                                                                        "reclaimedActivityDocs"));
-    currentDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
-    deletedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
-    insertedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
-    totalUpdatesCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
   }
 
   public void init() {
@@ -99,8 +93,13 @@ public class CompositeActivityValues {
   }
 
   public void init(int count) {
-    uidToArrayIndex = new Long2IntOpenHashMap(count);  
-    
+    uidToArrayIndex = new Long2IntOpenHashMap(count);
+      reclaimedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class,
+              "reclaimedActivityDocs"));
+      currentDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
+      deletedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
+      insertedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
+      totalUpdatesCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
   }
   
   public void updateVersion(String version) {

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity;
 
+import com.senseidb.metrics.MetricFactory;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.longs.Long2IntMap;
@@ -48,7 +49,6 @@ import com.senseidb.indexing.activity.primitives.ActivityFloatValues;
 import com.senseidb.indexing.activity.primitives.ActivityIntValues;
 import com.senseidb.indexing.activity.primitives.ActivityPrimitiveValues;
 import com.senseidb.indexing.activity.time.TimeAggregatedActivityValues;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
 
@@ -79,21 +79,21 @@ public class CompositeActivityValues {
   private volatile boolean closed;
   private ActivityConfig activityConfig;
   
-  protected static Counter reclaimedDocumentsCounter;
-  protected static Counter currentDocumentsCounter;
-  protected static Counter deletedDocumentsCounter;
-  protected static Counter insertedDocumentsCounter;
-  protected static Counter totalUpdatesCounter;
-  static {
-    reclaimedDocumentsCounter = Metrics.newCounter(new MetricName(CompositeActivityValues.class, "reclaimedActivityDocs"));
-    currentDocumentsCounter = Metrics.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
-    deletedDocumentsCounter = Metrics.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
-    insertedDocumentsCounter = Metrics.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
-    totalUpdatesCounter = Metrics.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
+  protected final Counter reclaimedDocumentsCounter;
+  protected final Counter currentDocumentsCounter;
+  protected final Counter deletedDocumentsCounter;
+  protected final Counter insertedDocumentsCounter;
+  protected final Counter totalUpdatesCounter;
+
+  CompositeActivityValues() {
+    reclaimedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class,
+                                                                        "reclaimedActivityDocs"));
+    currentDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
+    deletedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
+    insertedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
+    totalUpdatesCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
   }
-  CompositeActivityValues() {    
-   
-  }
+
   public void init() {
     init(DEFAULT_INITIAL_CAPACITY);   
   }

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/CompositeActivityValues.java
@@ -79,13 +79,19 @@ public class CompositeActivityValues {
   private volatile boolean closed;
   private ActivityConfig activityConfig;
   
-  protected Counter reclaimedDocumentsCounter;
-  protected Counter currentDocumentsCounter;
-  protected Counter deletedDocumentsCounter;
-  protected Counter insertedDocumentsCounter;
-  protected Counter totalUpdatesCounter;
+  protected final Counter reclaimedDocumentsCounter;
+  protected final Counter currentDocumentsCounter;
+  protected final Counter deletedDocumentsCounter;
+  protected final Counter insertedDocumentsCounter;
+  protected final Counter totalUpdatesCounter;
 
   CompositeActivityValues() {
+    reclaimedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class,
+                                                                        "reclaimedActivityDocs"));
+    currentDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
+    deletedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
+    insertedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
+    totalUpdatesCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
   }
 
   public void init() {
@@ -93,13 +99,8 @@ public class CompositeActivityValues {
   }
 
   public void init(int count) {
-    uidToArrayIndex = new Long2IntOpenHashMap(count);
-      reclaimedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class,
-              "reclaimedActivityDocs"));
-      currentDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "currentActivityDocs"));
-      deletedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "deletedActivityDocs"));
-      insertedDocumentsCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "insertedActivityDocs"));
-      totalUpdatesCounter = MetricFactory.newCounter(new MetricName(CompositeActivityValues.class, "totalUpdatesCounter"));
+    uidToArrayIndex = new Long2IntOpenHashMap(count);  
+    
   }
   
   public void updateVersion(String version) {

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/PurgeUnusedActivitiesJob.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/PurgeUnusedActivitiesJob.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity;
 
+import com.senseidb.metrics.MetricFactory;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 
 import java.io.IOException;
@@ -43,7 +44,6 @@ import proj.zoie.api.ZoieIndexReader;
 import com.browseengine.bobo.api.BoboIndexReader;
 import com.senseidb.conf.SenseiConfParams;
 import com.senseidb.plugin.SenseiPluginRegistry;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
@@ -53,9 +53,12 @@ public class PurgeUnusedActivitiesJob implements Runnable, PurgeUnusedActivities
   
   private final CompositeActivityValues compositeActivityValues;
   private final Set<IndexReaderFactory<ZoieIndexReader<BoboIndexReader>>> zoieSystems;
-  private static Timer timer = Metrics.newTimer(new MetricName(PurgeUnusedActivitiesJob.class, "purgeUnusedActivityIndexes"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
-  private static Counter foundActivitiesToPurge = Metrics.newCounter(new MetricName(PurgeUnusedActivitiesJob.class, "foundActivitiesToPurge"));
-  private static Counter recentUidsSavedFromPurge = Metrics.newCounter(new MetricName(PurgeUnusedActivitiesJob.class, "recentUidsSavedFromPurge"));
+  private final Timer timer = MetricFactory.newTimer(new MetricName(PurgeUnusedActivitiesJob.class,
+                                                                    "purgeUnusedActivityIndexes"),
+                                                     TimeUnit.MILLISECONDS,
+                                                     TimeUnit.SECONDS);
+  private final Counter foundActivitiesToPurge = MetricFactory.newCounter(new MetricName(PurgeUnusedActivitiesJob.class, "foundActivitiesToPurge"));
+  private final Counter recentUidsSavedFromPurge = MetricFactory.newCounter(new MetricName(PurgeUnusedActivitiesJob.class, "recentUidsSavedFromPurge"));
   
   protected ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/primitives/ActivityPrimitivesStorage.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/primitives/ActivityPrimitivesStorage.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity.primitives;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -32,7 +33,6 @@ import org.springframework.util.Assert;
 
 import com.senseidb.indexing.activity.AtomicFieldUpdate;
 import com.senseidb.metrics.MetricsConstants;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
 
@@ -54,13 +54,16 @@ public class ActivityPrimitivesStorage {
   private MappedByteBuffer buffer;
   private long fileLength; 
   private boolean activateMemoryMappedBuffers = true;
-  private static Timer timer;
+  private final Timer timer;
   private String fileName;
   
   public ActivityPrimitivesStorage(String fieldName, String indexDir) {
     this.fieldName = fieldName;
     this.indexDir = indexDir;
-    timer = Metrics.newTimer(new MetricName(MetricsConstants.Domain,"timer","initIntActivities-time-" + fieldName.replaceAll(":", "-"),"initIntActivities"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    timer = MetricFactory.newTimer(new MetricName(MetricsConstants.Domain,
+                                                  "timer",
+                                                  "initIntActivities-time-" + fieldName.replaceAll(":", "-"),
+                                                  "initIntActivities"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
    
   }
 

--- a/sensei-core/src/main/java/com/senseidb/indexing/activity/time/AggregatesUpdateJob.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/activity/time/AggregatesUpdateJob.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.indexing.activity.time;
 
+import com.senseidb.metrics.MetricFactory;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,7 +29,6 @@ import org.apache.log4j.Logger;
 import com.senseidb.indexing.activity.ActivityPersistenceFactory.AggregatesMetadata;
 import com.senseidb.indexing.activity.time.TimeAggregatedActivityValues.IntValueHolder;
 import com.senseidb.metrics.MetricsConstants;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
 
@@ -47,7 +47,12 @@ public class AggregatesUpdateJob implements Runnable {
   private final TimeAggregatedActivityValues timeAggregatedActivityValues;
   private final AggregatesMetadata aggregatesMetadata;
   private int currentCount;
-  private static Timer timer = Metrics.newTimer(new MetricName(MetricsConstants.Domain,"timer","updateJob-time","agregatesUpdateJob"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+  private final Timer timer = MetricFactory.newTimer(new MetricName(MetricsConstants.Domain,
+                                                                    "timer",
+                                                                    "updateJob-time",
+                                                                    "agregatesUpdateJob"),
+                                                     TimeUnit.MILLISECONDS,
+                                                     TimeUnit.SECONDS);
   
   public AggregatesUpdateJob(TimeAggregatedActivityValues timeAggregatedActivityValues, AggregatesMetadata aggregatesMetadata) {
     this.timeAggregatedActivityValues = timeAggregatedActivityValues;

--- a/sensei-core/src/main/java/com/senseidb/jmx/JmxUtil.java
+++ b/sensei-core/src/main/java/com/senseidb/jmx/JmxUtil.java
@@ -55,8 +55,8 @@ public class JmxUtil {
     ObjectName objectName = null;
     try
     {
-      log.info("registering jmx mbean: "+objectName);
       objectName = new ObjectName(MetricsConstants.Domain,key,val);
+      log.info("registering jmx mbean: "+objectName);
       MbeanServer.registerMBean(bean, objectName);
       RegisteredBeans.add(objectName);
     }

--- a/sensei-core/src/main/java/com/senseidb/jmx/JmxUtil.java
+++ b/sensei-core/src/main/java/com/senseidb/jmx/JmxUtil.java
@@ -69,8 +69,12 @@ public class JmxUtil {
       }
     }
   }
-  
-  private static void unregisterMBeans(){
+
+  /**
+   * Unregister all MBeans that are registered through the
+   * {@link #registerMBean(javax.management.StandardMBean, String, String)} method.
+   */
+  public static void unregisterMBeans(){
 	  for (ObjectName mbeanName : RegisteredBeans){
 	    try {
 	      log.info("unregistering jmx mbean: "+mbeanName);
@@ -82,11 +86,11 @@ public class JmxUtil {
 	  RegisteredBeans.clear();
   }
   
-  static{
-	  Runtime.getRuntime().addShutdownHook(new Thread(){
-		 public void run(){
-		   unregisterMBeans(); 
-		 }
-	  });
-  }
+//  static{
+//	  Runtime.getRuntime().addShutdownHook(new Thread(){
+//		 public void run(){
+//		   unregisterMBeans();
+//		 }
+//	  });
+//  }
 }

--- a/sensei-core/src/main/java/com/senseidb/metrics/MetricFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/metrics/MetricFactory.java
@@ -1,0 +1,114 @@
+package com.senseidb.metrics;
+
+
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.reporting.JmxReporter;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+/**
+ * Factory class for creating metric instances. It replaces the {@link com.yammer.metrics.Metrics} class
+ * so that the {@link com.yammer.metrics.core.MetricsRegistry} used can be start and stop.
+ */
+public final class MetricFactory {
+
+  private static final AtomicReference<MetricFactory> FACTORY = new AtomicReference<MetricFactory>();
+
+  private final MetricsRegistry _registry;
+  private final JmxReporter _reporter;
+
+  /**
+   * Starts a new MetricFactory. If there exists an old MetricFactory, it will be stopped.
+   */
+  public static void start() {
+    MetricFactory oldFactory = FACTORY.getAndSet(new MetricFactory().startAll());
+    if (oldFactory != null) {
+      oldFactory.stopAll();
+    }
+  }
+
+  /**
+   * Stops the current MetricFactory. It will stop all threads owned by the factory and unregister all mbeans
+   * created through the factory.
+   */
+  public static void stop() {
+    MetricFactory oldFactory = FACTORY.getAndSet(null);
+    if (oldFactory != null) {
+      oldFactory.stopAll();
+    }
+  }
+
+  /**
+   * @see MetricsRegistry#newTimer(com.yammer.metrics.core.MetricName, java.util.concurrent.TimeUnit, java.util.concurrent.TimeUnit)
+   */
+  public static Timer newTimer(MetricName metricName,
+                        TimeUnit durationUnit,
+                        TimeUnit rateUnit) {
+    return getRegistry().newTimer(metricName, durationUnit, rateUnit);
+  }
+
+  /**
+   * @see MetricsRegistry#newMeter(com.yammer.metrics.core.MetricName, String, java.util.concurrent.TimeUnit)
+   */
+  public static Meter newMeter(MetricName metricName,
+                        String eventType,
+                        TimeUnit unit) {
+    return getRegistry().newMeter(metricName, eventType, unit);
+  }
+
+  /**
+   * @see MetricsRegistry#newCounter(com.yammer.metrics.core.MetricName)
+   */
+  public static Counter newCounter(MetricName metricName) {
+    return getRegistry().newCounter(metricName);
+  }
+
+  /**
+   * @see MetricsRegistry#newHistogram(com.yammer.metrics.core.MetricName, boolean)
+   */
+  public static Histogram newHistogram(MetricName metricName, boolean biased) {
+    return getRegistry().newHistogram(metricName, biased);
+  }
+
+  /**
+   * Returns a {@link MetricsRegistry}. It will start this factory if it is not started.
+   */
+  private static MetricsRegistry getRegistry() {
+    MetricFactory factory = FACTORY.get();
+    while (factory == null) {
+      start();
+      factory = FACTORY.get();
+    }
+    return factory._registry;
+  }
+
+  private MetricFactory() {
+    _registry = new MetricsRegistry();
+    _reporter = new JmxReporter(_registry);
+  }
+
+  /**
+   * Starts the {@link JmxReporter}.
+   *
+   * @return this instance.
+   */
+  private MetricFactory startAll() {
+    _reporter.start();
+    return this;
+  }
+
+  /**
+   * Stops all threads owned by the {@link MetricsRegistry} and unregister
+   * all mbeans owned by {@link JmxReporter}.
+   */
+  private void stopAll() {
+    _registry.shutdown();
+    _reporter.shutdown();
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/node/AbstractConsistentHashBroker.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/AbstractConsistentHashBroker.java
@@ -23,37 +23,31 @@ import com.linkedin.norbert.network.ResponseIterator;
 import com.linkedin.norbert.network.common.ExceptionIterator;
 import com.linkedin.norbert.network.common.PartialIterator;
 import com.linkedin.norbert.network.common.TimeoutIterator;
+import com.senseidb.metrics.MetricFactory;
 import com.senseidb.search.req.SenseiRequest;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.linkedin.norbert.NorbertException;
 import com.linkedin.norbert.javacompat.cluster.Node;
 import com.linkedin.norbert.javacompat.network.PartitionedNetworkClient;
 import com.linkedin.norbert.network.Serializer;
-import com.senseidb.cluster.routing.RoutingInfo;
 import com.senseidb.metrics.MetricsConstants;
 import com.senseidb.search.req.AbstractSenseiRequest;
 import com.senseidb.search.req.AbstractSenseiResult;
 import com.senseidb.search.req.ErrorType;
 import com.senseidb.search.req.SenseiError;
 import com.senseidb.svc.api.SenseiException;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
@@ -72,38 +66,12 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
   protected long _timeout = 8000;
   protected final Serializer<REQUEST, RESULT> _serializer;
 
-  private static Timer ScatterTimer = null;
-  private static Timer GatherTimer = null;
-  private static Timer TotalTimer = null;
-  private static Meter SearchCounter = null;
-  private static Meter ErrorMeter = null;
-  private static Meter EmptyMeter = null;
-  
-  static{
-	  // register metrics monitoring for timers
-	  try{
-	    MetricName scatterMetricName = new MetricName(MetricsConstants.Domain,"timer","scatter-time","broker");
-	    ScatterTimer = Metrics.newTimer(scatterMetricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-	    
-	    MetricName gatherMetricName = new MetricName(MetricsConstants.Domain,"timer","gather-time","broker");
-	    GatherTimer = Metrics.newTimer(gatherMetricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-
-	    MetricName totalMetricName = new MetricName(MetricsConstants.Domain,"timer","total-time","broker");
-	    TotalTimer = Metrics.newTimer(totalMetricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-	    
-	    MetricName searchCounterMetricName = new MetricName(MetricsConstants.Domain,"meter","search-count","broker");
-	    SearchCounter = Metrics.newMeter(searchCounterMetricName, "requets", TimeUnit.SECONDS);
-
-	    MetricName errorMetricName = new MetricName(MetricsConstants.Domain,"meter","error-meter","broker");
-	    ErrorMeter = Metrics.newMeter(errorMetricName, "errors",TimeUnit.SECONDS);
-	    
-	    MetricName emptyMetricName = new MetricName(MetricsConstants.Domain,"meter","empty-meter","broker");
-	    EmptyMeter = Metrics.newMeter(emptyMetricName, "null-hits", TimeUnit.SECONDS);
-	  }
-	  catch(Exception e){
-		logger.error(e.getMessage(),e);
-	  }
-  }
+  private final Timer _scatterTimer;
+  private final Timer _gatherTimer;
+  private final Timer _totalTimer;
+  private final Meter _searchCounter;
+  private final Meter _errorMeter;
+  private final Meter _emptyMeter;
   
   /**
    * @param networkClient
@@ -119,6 +87,25 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
   {
     super(networkClient);
     _serializer = serializer;
+
+    // register metrics monitoring for timers
+    MetricName scatterMetricName = new MetricName(MetricsConstants.Domain,"timer","scatter-time","broker");
+    _scatterTimer = MetricFactory.newTimer(scatterMetricName, TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+
+    MetricName gatherMetricName = new MetricName(MetricsConstants.Domain,"timer","gather-time","broker");
+    _gatherTimer = MetricFactory.newTimer(gatherMetricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
+
+    MetricName totalMetricName = new MetricName(MetricsConstants.Domain,"timer","total-time","broker");
+    _totalTimer = MetricFactory.newTimer(totalMetricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
+
+    MetricName searchCounterMetricName = new MetricName(MetricsConstants.Domain,"meter","search-count","broker");
+    _searchCounter = MetricFactory.newMeter(searchCounterMetricName, "requets", TimeUnit.SECONDS);
+
+    MetricName errorMetricName = new MetricName(MetricsConstants.Domain,"meter","error-meter","broker");
+    _errorMeter = MetricFactory.newMeter(errorMetricName, "errors",TimeUnit.SECONDS);
+
+    MetricName emptyMetricName = new MetricName(MetricsConstants.Domain,"meter","empty-meter","broker");
+    _emptyMeter = MetricFactory.newMeter(emptyMetricName, "null-hits", TimeUnit.SECONDS);
   }
 
 	public <T> T customizeRequest(REQUEST request)
@@ -155,10 +142,10 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
 //      ErrorMeter.mark();
 //      throw new SenseiException("Browse called before cluster is connected!");
 //    }
-    SearchCounter.mark();
+    _searchCounter.mark();
     try
     {
-      return TotalTimer.time(new Callable<RESULT>(){
+      return _totalTimer.time(new Callable<RESULT>(){
     	@Override
   		public RESULT call() throws Exception {
           return doBrowse(_networkClient, req, _partitions); 	  
@@ -167,7 +154,7 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
     } 
     catch (Exception e)
     {
-      ErrorMeter.mark();
+      _errorMeter.mark();
       throw new SenseiException(e.getMessage(), e);
     }
   }
@@ -201,14 +188,17 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
     final List<RESULT> resultList = new ArrayList<RESULT>();
    
     try {
-      resultList.addAll(ScatterTimer.time(new Callable<List<RESULT>>() {
+      resultList.addAll(_scatterTimer.time(new Callable<List<RESULT>>()
+      {
         @Override
-        public List<RESULT> call() throws Exception {
+        public List<RESULT> call()
+            throws Exception
+        {
           return doCall(req);
         }
       }));
     } catch (Exception e) {
-      ErrorMeter.mark();
+      _errorMeter.mark();
       RESULT emptyResult = getEmptyResultInstance();
       logger.error("Error running scatter/gather", e);
       emptyResult.addError(new SenseiError("Error gathering the results" + e.getMessage(), ErrorType.BrokerGatherError));
@@ -220,13 +210,13 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
       logger.error("no result received at all return empty result");
       RESULT emptyResult = getEmptyResultInstance();
       emptyResult.addError(new SenseiError("Error gathering the results. " + "no result received at all return empty result", ErrorType.BrokerGatherError));
-      EmptyMeter.mark();
+      _emptyMeter.mark();
       return emptyResult;
     }
 
     RESULT result = null;
     try {
-      result = GatherTimer.time(new Callable<RESULT>() {
+      result = _gatherTimer.time(new Callable<RESULT>() {
         @Override
         public RESULT call() throws Exception {
           return mergeResults(req, resultList);
@@ -236,7 +226,7 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
       result = getEmptyResultInstance();
       logger.error("Error gathering the results", e);
       result.addError(new SenseiError("Error gathering the results" + e.getMessage(), ErrorType.BrokerGatherError));
-      ErrorMeter.mark();
+      _errorMeter.mark();
     }
 
     if (logger.isDebugEnabled()){
@@ -283,6 +273,24 @@ public abstract class AbstractConsistentHashBroker<REQUEST extends AbstractSense
   public void shutdown()
   {
     logger.info("shutting down broker...");
+    if (_scatterTimer != null) {
+      _scatterTimer.stop();
+    }
+    if (_gatherTimer != null) {
+      _gatherTimer.stop();
+    }
+    if (_totalTimer != null) {
+      _totalTimer.stop();
+    }
+    if (_searchCounter != null) {
+      _searchCounter.stop();
+    }
+    if (_errorMeter != null) {
+      _errorMeter.stop();
+    }
+    if (_emptyMeter != null) {
+      _emptyMeter.stop();
+    }
   }
 
   

--- a/sensei-core/src/main/java/com/senseidb/search/node/SenseiBroker.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/SenseiBroker.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.search.node;
 
+import com.senseidb.metrics.MetricFactory;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 
 import java.lang.management.ManagementFactory;
@@ -46,7 +47,6 @@ import com.senseidb.search.req.SenseiHit;
 import com.senseidb.search.req.SenseiRequest;
 import com.senseidb.search.req.SenseiResult;
 import com.senseidb.svc.impl.CoreSenseiServiceImpl;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
 
@@ -64,7 +64,8 @@ public class SenseiBroker extends AbstractConsistentHashBroker<SenseiRequest, Se
  
   private final boolean allowPartialMerge;
   private final ClusterClient clusterClient;
-  private static Counter numberOfNodesInTheCluster = Metrics.newCounter(new MetricName(SenseiBroker.class, "numberOfNodesInTheCluster"));
+  private final Counter numberOfNodesInTheCluster = MetricFactory.newCounter(new MetricName(SenseiBroker.class,
+                                                                                            "numberOfNodesInTheCluster"));
   
   public SenseiBroker(PartitionedNetworkClient<String> networkClient, ClusterClient clusterClient, boolean allowPartialMerge)
       throws NorbertException {

--- a/sensei-core/src/main/java/com/senseidb/search/node/SenseiServer.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/SenseiServer.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.search.node;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -62,7 +63,6 @@ public class SenseiServer {
   private ClusterClient _clusterClient;
   private final SenseiCore _core;
   protected volatile Node _serverNode;
-  private final CoreSenseiServiceImpl _innerSvc;
   private final List<AbstractSenseiCoreService<AbstractSenseiRequest, AbstractSenseiResult>> _externalSvc;
 
   //private Server _adminServer;
@@ -96,8 +96,6 @@ public class SenseiServer {
 
     _networkServer = networkServer;
     _clusterClient = clusterClient;
-
-    _innerSvc = new CoreSenseiServiceImpl(senseiCore);
     _externalSvc = externalSvc;
   }
 
@@ -150,7 +148,7 @@ public class SenseiServer {
     try {
       logger.info("shutting down node...");
       try
-      {        
+      {
         _core.shutdown();
         pluginRegistry.stop();
         _clusterClient.removeNode(_id);
@@ -170,9 +168,12 @@ public class SenseiServer {
     } catch (Exception e) {
       logger.error(e.getMessage(),e);
     }
+    MetricFactory.stop();
+    JmxUtil.unregisterMBeans();
   }
 
   public void start(boolean available) throws Exception {
+    MetricFactory.start();
     _core.start();
 //        ClusterClient clusterClient = ClusterClientFactory.newInstance().newZookeeperClient();
     String clusterName = _clusterClient.getServiceName();
@@ -181,15 +182,16 @@ public class SenseiServer {
     logger.info("Cluster info: " + _clusterClient.toString());
 
     AbstractSenseiCoreService coreSenseiService = new CoreSenseiServiceImpl(_core);
-    AbstractSenseiCoreService sysSenseiCoreService = new SysSenseiCoreServiceImpl(_core);    
+    AbstractSenseiCoreService sysSenseiCoreService = new SysSenseiCoreServiceImpl(_core);
+
     // create the zookeeper cluster client
 //    SenseiClusterClientImpl senseiClusterClient = new SenseiClusterClientImpl(clusterName, zookeeperURL, zookeeperTimeout, false);
     SenseiCoreServiceMessageHandler senseiMsgHandler =  new SenseiCoreServiceMessageHandler(coreSenseiService);
     SenseiCoreServiceMessageHandler senseiSysMsgHandler =  new SenseiCoreServiceMessageHandler(sysSenseiCoreService);
-   
+
     _networkServer.registerHandler(senseiMsgHandler, coreSenseiService.getSerializer());
     _networkServer.registerHandler(senseiSysMsgHandler, sysSenseiCoreService.getSerializer());
-    
+
     _networkServer.registerHandler(senseiMsgHandler, CoreSenseiServiceImpl.JAVA_SERIALIZER);
     _networkServer.registerHandler(senseiSysMsgHandler, SysSenseiCoreServiceImpl.JAVA_SERIALIZER);
 

--- a/sensei-core/src/main/java/com/senseidb/search/node/SenseiZoieSystemFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/SenseiZoieSystemFactory.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.search.node;
 
+import com.senseidb.metrics.MetricFactory;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,6 @@ import proj.zoie.impl.indexing.ZoieSystem;
 
 import com.browseengine.bobo.api.BoboIndexReader;
 import com.senseidb.metrics.MetricsConstants;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.MetricName;
@@ -116,13 +116,13 @@ public class SenseiZoieSystemFactory<T> extends SenseiZoieFactory<T>
         
     IndexingMetrics(int partition){
       MetricName docsIndexedName =  new MetricName(MetricsConstants.Domain,"meter","docs-indexed","indexer");
-      docsIndexedMetric = Metrics.newMeter(docsIndexedName, "indexing", TimeUnit.SECONDS);
+      docsIndexedMetric = MetricFactory.newMeter(docsIndexedName, "indexing", TimeUnit.SECONDS);
 
       MetricName docsLeftoverName = new MetricName(MetricsConstants.Domain,"meter","docs-leftover","indexer");
-      docsLeftoverMetric = Metrics.newMeter(docsLeftoverName, "indexing", TimeUnit.SECONDS);
+      docsLeftoverMetric = MetricFactory.newMeter(docsLeftoverName, "indexing", TimeUnit.SECONDS);
 
       MetricName flushTimeName = new MetricName(MetricsConstants.Domain,"histogram","flush-time","indexer");
-      flushTimeHistogram = Metrics.newHistogram(flushTimeName, false);
+      flushTimeHistogram = MetricFactory.newHistogram(flushTimeName, false);
     }
   }
 }

--- a/sensei-core/src/main/java/com/senseidb/svc/impl/AbstractSenseiCoreService.java
+++ b/sensei-core/src/main/java/com/senseidb/svc/impl/AbstractSenseiCoreService.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.svc.impl;
 
+import com.senseidb.metrics.MetricFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +48,6 @@ import com.senseidb.search.req.AbstractSenseiRequest;
 import com.senseidb.search.req.AbstractSenseiResult;
 import com.senseidb.search.req.ErrorType;
 import com.senseidb.search.req.SenseiError;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
@@ -56,31 +56,11 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
   private final static Logger logger = Logger.getLogger(AbstractSenseiCoreService.class);
   
 
-  private static Timer GetReaderTimer = null;
-  private static Timer SearchTimer = null;
-  private static Timer MergeTimer = null;
-  private static Meter SearchCounter = null;
-	
-  static{
-	  // register jmx monitoring for timers
-	  try{
-	    MetricName getReaderMetricName = new MetricName(MetricsConstants.Domain,"timer","getreader-time","node");
-	    GetReaderTimer = Metrics.newTimer(getReaderMetricName,TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-	    
-	    MetricName searchMetricName = new MetricName(MetricsConstants.Domain,"timer","search-time","node");
-	    SearchTimer = Metrics.newTimer(searchMetricName,TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
+  private final Timer _getReaderTimer;
+  private final Timer _searchTimer;
+  private final Timer _mergeTimer;
+  private final Meter _searchCounter;
 
-	    MetricName mergeMetricName = new MetricName(MetricsConstants.Domain,"timer","merge-time","node");
-	    MergeTimer = Metrics.newTimer(mergeMetricName,TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-	    
-	    MetricName searchCounterMetricName = new MetricName(MetricsConstants.Domain,"meter","search-count","node");
-	    SearchCounter = Metrics.newMeter(searchCounterMetricName, "requets", TimeUnit.SECONDS);
-
-	  }
-	  catch(Exception e){
-		logger.error(e.getMessage(),e);
-	  }
-  }
   protected long _timeout = 8000;
     
   protected final SenseiCore _core;
@@ -92,12 +72,17 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
 	
 	public AbstractSenseiCoreService(SenseiCore core){
 	  _core = core;
-	  int[] partitions = _core.getPartitions();
+    _getReaderTimer = registerTimer("getreader-time");
+    _searchTimer = registerTimer("search-time");
+    _mergeTimer = registerTimer("merge-time");
+
+    // TODO: requets is a mis-spell. Can we fix it?
+    _searchCounter = registerMeter("search-count", "requets");
 	}
   
   private Timer buildTimer(int partition) {
     MetricName partitionSearchMetricName = new MetricName(MetricsConstants.Domain,"timer","partition-time-"+partition,"partition");
-    return Metrics.newTimer(partitionSearchMetricName,TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
+    return MetricFactory.newTimer(partitionSearchMetricName,TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
   }
   
   private Timer getTimer(int partition) {
@@ -110,7 +95,7 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
   }
 	
 	public final Res execute(final Req senseiReq){
-		SearchCounter.mark();
+		_searchCounter.mark();
 		Set<Integer> partitions = senseiReq==null ? null : senseiReq.getPartitions();
 		if (partitions==null){
 			partitions = new HashSet<Integer>();
@@ -215,7 +200,7 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
         }
 
           try{
-	        finalResult = MergeTimer.time(new Callable<Res>(){
+	        finalResult = _mergeTimer.time(new Callable<Res>(){
 	    	 public Res call() throws Exception{
 	    	   return mergePartitionedResults(senseiReq, resultList);
 	    	 }
@@ -244,7 +229,7 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
 	private final Res handleRequest(final Req senseiReq,final IndexReaderFactory<ZoieIndexReader<BoboIndexReader>> readerFactory,final SenseiQueryBuilderFactory queryBuilderFactory) throws Exception{
 		List<ZoieIndexReader<BoboIndexReader>> readerList = null;
         try{
-      	  readerList = GetReaderTimer.time(new Callable<List<ZoieIndexReader<BoboIndexReader>>>(){
+      	  readerList = _getReaderTimer.time(new Callable<List<ZoieIndexReader<BoboIndexReader>>>(){
       		 public List<ZoieIndexReader<BoboIndexReader>> call() throws Exception{
             if (readerFactory == null)
               return Collections.EMPTY_LIST;
@@ -256,7 +241,7 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
       	  }
       	  final List<BoboIndexReader> boboReaders = ZoieIndexReader.extractDecoratedReaders(readerList);
       	  
-      	  return SearchTimer.time(new Callable<Res>(){
+      	  return _searchTimer.time(new Callable<Res>(){
       		public Res call() throws Exception{
       		  return handlePartitionedRequest(senseiReq,boboReaders,queryBuilderFactory);
       		}
@@ -268,10 +253,28 @@ public abstract class AbstractSenseiCoreService<Req extends AbstractSenseiReques
           }
         }
 	}
+
+  protected final Timer registerTimer(String name)
+  {
+    return MetricFactory.newTimer(new MetricName(MetricsConstants.Domain, "timer", name, getMetricScope()),
+                                  TimeUnit.MILLISECONDS,
+                                  TimeUnit.SECONDS);
+  }
+
+  protected final Meter registerMeter(String name, String eventType)
+  {
+    return MetricFactory.newMeter(new MetricName(MetricsConstants.Domain, "meter", name, getMetricScope()), eventType, TimeUnit.SECONDS);
+  }
 	
 	public abstract Res handlePartitionedRequest(Req r,final List<BoboIndexReader> readerList,SenseiQueryBuilderFactory queryBuilderFactory) throws Exception;
 	public abstract Res mergePartitionedResults(Req r,List<Res> reqList);
 	public abstract Res getEmptyResultInstance(Throwable error);
 
 	public abstract Serializer<Req, Res> getSerializer();
+
+  /**
+   * Returns the name of the metric scope. It's used for creating {@link MetricName} that get registered through
+   * {@link MetricFactory}.
+   */
+  protected abstract String getMetricScope();
 }

--- a/sensei-core/src/main/java/com/senseidb/svc/impl/SenseiCoreServiceMessageHandler.java
+++ b/sensei-core/src/main/java/com/senseidb/svc/impl/SenseiCoreServiceMessageHandler.java
@@ -18,6 +18,7 @@
  */
 package com.senseidb.svc.impl;
 
+import com.senseidb.metrics.MetricFactory;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +28,6 @@ import com.linkedin.norbert.javacompat.network.RequestHandler;
 import com.senseidb.metrics.MetricsConstants;
 import com.senseidb.search.req.AbstractSenseiRequest;
 import com.senseidb.search.req.AbstractSenseiResult;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Timer;
 
@@ -35,25 +35,17 @@ public final class SenseiCoreServiceMessageHandler<REQUEST extends AbstractSense
 	private static final Logger logger = Logger.getLogger(SenseiCoreServiceMessageHandler.class);
     private final AbstractSenseiCoreService<REQUEST, RESULT> _svc;
 
-    private static Timer TotalSearchTimer = null;
-    static{
-  	  // register jmx monitoring for timers
-  	  try{
-  	    MetricName metricName = new MetricName(MetricsConstants.Domain,"timer","total-search-time","node");
-  	    TotalSearchTimer = Metrics.newTimer(metricName, TimeUnit.MILLISECONDS,TimeUnit.SECONDS);
-  	  }
-	    catch(Exception e){
-		    logger.error(e.getMessage(),e);
-	    }
-    }
-    
+    private final Timer _totalSearchTimer;
+
     public SenseiCoreServiceMessageHandler(AbstractSenseiCoreService<REQUEST, RESULT> svc){
 		  _svc = svc;
+      MetricName metricName = new MetricName(MetricsConstants.Domain,"timer","total-search-time","node");
+      _totalSearchTimer = MetricFactory.newTimer(metricName, TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
 	  }
 
     @Override
     public RESULT handleRequest(final REQUEST request) throws Exception {
-        return TotalSearchTimer.time(new Callable<RESULT>(){
+        return _totalSearchTimer.time(new Callable<RESULT>(){
 
             @Override
             public RESULT call() throws Exception {

--- a/sensei-core/src/main/java/com/senseidb/svc/impl/SysSenseiCoreServiceImpl.java
+++ b/sensei-core/src/main/java/com/senseidb/svc/impl/SysSenseiCoreServiceImpl.java
@@ -50,7 +50,7 @@ public class SysSenseiCoreServiceImpl extends AbstractSenseiCoreService<SenseiRe
   @Override
   protected String getMetricScope()
   {
-    return "node";
+    return "sys";
   }
 
   @Override

--- a/sensei-core/src/main/java/com/senseidb/svc/impl/SysSenseiCoreServiceImpl.java
+++ b/sensei-core/src/main/java/com/senseidb/svc/impl/SysSenseiCoreServiceImpl.java
@@ -46,7 +46,13 @@ public class SysSenseiCoreServiceImpl extends AbstractSenseiCoreService<SenseiRe
   public SysSenseiCoreServiceImpl(SenseiCore core) {
     super(core);
   }
-  
+
+  @Override
+  protected String getMetricScope()
+  {
+    return "node";
+  }
+
   @Override
   public SenseiSystemInfo handlePartitionedRequest(SenseiRequest request,
       List<BoboIndexReader> readerList,SenseiQueryBuilderFactory queryBuilderFactory) throws Exception {


### PR DESCRIPTION
Original, the metrics related threads and mbeans are cleanup by shutdown hook. The major changes is to replaces usage of Metrics.xxx() to MetricFactory.xxx(), which the MetricFactory provides static start and stop methods that will be called when sensei server start/stop accordingly, allowing proper resources cleanup.
