### PR TITLE
Added support for indexing fields with regular expressions

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/conf/SchemaConverter.java
+++ b/sensei-core/src/main/java/com/senseidb/conf/SchemaConverter.java
@@ -93,7 +93,9 @@ public class SchemaConverter
 
           columnObj.put("multi", Boolean.parseBoolean(column.getAttribute("multi")));
           columnObj.put("activity", Boolean.parseBoolean(column.getAttribute("activity")));
-          String delimString = column.getAttribute("delimiter");
+          columnObj.put("wildcard", Boolean.parseBoolean(column.getAttribute("wildcard")));
+
+            String delimString = column.getAttribute("delimiter");
           if (delimString != null && delimString.trim().length() > 0)
           {
             columnObj.put("delimiter", delimString);

--- a/sensei-core/src/test/java/com/senseidb/test/TestSensei.java
+++ b/sensei-core/src/test/java/com/senseidb/test/TestSensei.java
@@ -1139,7 +1139,22 @@ public class TestSensei extends TestCase {
     assertEquals("color for first is not correct." , true, color.equals("red") );
     assertEquals("inner score for first is not correct." , true, Math.abs(firstScore - 20000) < 1 );
   }
-  
+
+    /**
+     * Verify that fields added using wildcards can be queried.
+     */
+  public void testDynamicFieldQueryStringQuery() throws Exception
+  {
+      logger.info("executing test case testDynamicFieldQueryStringQuery");
+      String req = "{\"query\": {\"query_string\": {\"query\": \"dynamic_text_field_1:dynamic\"}}}";
+      JSONObject res = search(new JSONObject(req));
+      assertEquals("numhits is wrong", 1, res.getInt("numhits"));
+
+      String req2 = "{\"query\": {\"query_string\": {\"query\": \"dynamic_text_field_43:wagon\"}}}";
+      JSONObject res2 = search(new JSONObject(req2));
+      assertEquals("numhits is wrong", 1, res2.getInt("numhits"));
+
+  }
 
   private boolean containsString(JSONArray array, String target) throws JSONException
   {

--- a/sensei-core/src/test/resources/test-conf/node1/schema.xml
+++ b/sensei-core/src/test/resources/test-conf/node1/schema.xml
@@ -35,6 +35,7 @@
 	<!-- attributes: indexed,store,termvector are only used when type is text -->
 	<column name="contents" type="text" index="ANALYZED" store="NO" termvector="NO" />
 	<column name="object_properties" type="string" multi="true" delimiter=","/>
+	<column name="dynamic_text_field_.*" type="text" index="ANALYZED" store="NO" termvector="NO" wildcard="true"/>
   </table>
 
    <!-- 

--- a/sensei-core/src/test/resources/test-conf/node2/schema.xml
+++ b/sensei-core/src/test/resources/test-conf/node2/schema.xml
@@ -35,6 +35,7 @@
 	<column name="object_properties" type="string" multi="true" delimiter=","/>
 	<!-- attributes: indexed,store,termvector are only used when type is text -->
 	<column name="contents" type="text" index="ANALYZED" store="NO" termvector="NO" />
+	<column name="dynamic_text_field_.*" type="text" index="ANALYZED" store="NO" termvector="NO" wildcard="true"/>
   </table>
 
    <!-- 
@@ -125,7 +126,7 @@
 		  <param name="time" value="2w" />
 		</params>
 		</facet>	
-		
+	 	
 	 <!-- example of a custom facet, defined in custom-facets.xml -->
 	 <!-- 
 	     a bean with name "foobar" must be defined


### PR DESCRIPTION
For an indexing column , you can now specify a new attribute, "wildcard" in the configuration,  which indicates that the "name" may have regular expressions that will be matched against all the fields in the input document. The syntax for regex is the same as specified by Java language. Any matches will then be processed and indexed as specified in the schema. Since a column name can match several fields in a document, the name added to the index is always the field name in the document. For columns with wildcards, it is an error to specify different values for "name" and "from" attributes. 
