### PR TITLE
Removing inMemorySenseiServiceClass, which improperly uses of JVM

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/indexing/DefaultStreamingIndexingManager.java
+++ b/sensei-core/src/main/java/com/senseidb/indexing/DefaultStreamingIndexingManager.java
@@ -151,7 +151,7 @@ public class DefaultStreamingIndexingManager implements SenseiIndexingManager<JS
 		StreamDataProvider<JSONObject> dataProvider = null;
     if (_gateway!=null){
 		  try{
-		    dataProvider = _gateway.buildDataProvider(_senseiSchema, _oldestSinceKey, pluginRegistry,_shardingStrategy,_dataCollectorMap.keySet());
+		    dataProvider = _gateway.buildDataProvider(_senseiSchema, _oldestSinceKey, pluginRegistry,_shardingStrategy,_zoieSystemMap.keySet());
         long maxEventsPerMin = _myconfig.getLong(EVTS_PER_MIN,40000);
         dataProvider.setMaxEventsPerMinute(maxEventsPerMin);
         int batchSize = _myconfig.getInt(BATCH_SIZE,1);

--- a/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiClientServlet.java
+++ b/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiClientServlet.java
@@ -402,7 +402,7 @@ public abstract class AbstractSenseiClientServlet extends ZookeeperConfigurableS
       }
       SenseiResult res = _senseiBroker.browse(senseiReq);
       OutputStream ostream = resp.getOutputStream();
-      convertResult(senseiReq, res, ostream);
+      convertResult(req, senseiReq, res, ostream);
       ostream.flush();
     }
     catch (Exception e)
@@ -480,7 +480,7 @@ public abstract class AbstractSenseiClientServlet extends ZookeeperConfigurableS
     try {
       SenseiSystemInfo res = _senseiSysBroker.browse(new SenseiRequest());
       OutputStream ostream = resp.getOutputStream();
-      convertResult(res, ostream);
+      convertResult(req, res, ostream);
       ostream.flush();
     } catch (Exception e) {
       throw new ServletException(e.getMessage(),e);
@@ -606,9 +606,9 @@ public abstract class AbstractSenseiClientServlet extends ZookeeperConfigurableS
     resp.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, X-Requested-With, Accept");
   }
 
-  protected abstract void convertResult(SenseiSystemInfo info, OutputStream ostream) throws Exception;
+  protected abstract void convertResult(HttpServletRequest httpReq, SenseiSystemInfo info, OutputStream ostream) throws Exception;
 
-  protected abstract void convertResult(SenseiRequest req,SenseiResult res,OutputStream ostream) throws Exception;
+  protected abstract void convertResult(HttpServletRequest httpReq, SenseiRequest req,SenseiResult res,OutputStream ostream) throws Exception;
 
   @Override
   public void destroy() {

--- a/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiRestServlet.java
+++ b/sensei-core/src/main/java/com/senseidb/servlet/AbstractSenseiRestServlet.java
@@ -27,21 +27,21 @@ public abstract class AbstractSenseiRestServlet extends AbstractSenseiClientServ
 		return buildSenseiRequest(params);
 	}
 	
-	abstract protected String buildResultString(SenseiRequest req,SenseiResult res) throws Exception;
+	abstract protected String buildResultString(HttpServletRequest httpReq, SenseiRequest req,SenseiResult res) throws Exception;
 
-	abstract protected String buildResultString(SenseiSystemInfo info) throws Exception;
+	abstract protected String buildResultString(HttpServletRequest httpReq, SenseiSystemInfo info) throws Exception;
 
 	@Override
-	protected void convertResult(SenseiSystemInfo info, OutputStream ostream)
+	protected void convertResult(HttpServletRequest httpReq, SenseiSystemInfo info, OutputStream ostream)
 			throws Exception {
-		String outString = buildResultString(info);
+		String outString = buildResultString(httpReq, info);
 		ostream.write(outString.getBytes("UTF-8"));
 	}
 
 	@Override
-	protected void convertResult(SenseiRequest req,SenseiResult res, OutputStream ostream)
+	protected void convertResult(HttpServletRequest httpReq, SenseiRequest req,SenseiResult res, OutputStream ostream)
 			throws Exception {
-		String outString = buildResultString(req,res);
+		String outString = buildResultString(httpReq, req,res);
 		ostream.write(outString.getBytes("UTF-8"));
 	}
 }

--- a/sensei-core/src/main/java/com/senseidb/servlet/DefaultSenseiJSONServlet.java
+++ b/sensei-core/src/main/java/com/senseidb/servlet/DefaultSenseiJSONServlet.java
@@ -96,6 +96,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.DataConfiguration;
 import org.apache.commons.lang.StringUtils;
@@ -294,10 +296,19 @@ public class DefaultSenseiJSONServlet extends AbstractSenseiRestServlet
   }
 
   @Override
-  protected String buildResultString(SenseiRequest req, SenseiResult res)
+  protected String buildResultString(HttpServletRequest httpReq, SenseiRequest req, SenseiResult res)
       throws Exception
   {
-    return buildJSONResultString(req, res);
+    return supportJsonp(httpReq, buildJSONResultString(req, res));
+  }
+
+  private String supportJsonp(HttpServletRequest httpReq, String jsonString) {
+    String callback = httpReq.getParameter("callback");
+    if (callback != null) {
+      return callback + "(" + jsonString + ");";
+    } else {
+      return jsonString;
+    }   
   }
 
   public static String buildJSONResultString(SenseiRequest req, SenseiResult res)
@@ -884,7 +895,7 @@ public class DefaultSenseiJSONServlet extends AbstractSenseiRestServlet
   }
 
   @Override
-  protected String buildResultString(SenseiSystemInfo info) throws Exception {
+  protected String buildResultString(HttpServletRequest httpReq, SenseiSystemInfo info) throws Exception {
     JSONObject jsonObj = new JSONObject();
     jsonObj.put(PARAM_SYSINFO_NUMDOCS, info.getNumDocs());
     jsonObj.put(PARAM_SYSINFO_LASTMODIFIED, info.getLastModified());
@@ -924,6 +935,6 @@ public class DefaultSenseiJSONServlet extends AbstractSenseiRestServlet
       }
     }
 
-    return jsonObj.toString();
+    return supportJsonp(httpReq, jsonObj.toString());
   }
 }


### PR DESCRIPTION
Removing inMemorySenseiServiceClass, which improperly uses of JVM. Details in https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/Sensei+JMX+NPE+Problem
Seas doesn’t use this class. Removing this class and associated classes to prevent future use. 
CNC version of Sensei causes a issue. JIra - SI 571. 
