### PR TITLE
Adding the ability for sensei filters to estimate cardinality to optimize filter execution order

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/search/node/broker/BrokerConfig.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/broker/BrokerConfig.java
@@ -69,8 +69,8 @@ public class BrokerConfig {
     zkurl = senseiConf.getString(SenseiConfigServletContextListener.SENSEI_CONF_ZKURL, zkurl);
     clusterName = senseiConf.getString(SenseiConfigServletContextListener.SENSEI_CONF_CLUSTER_NAME, clusterName);
     zkTimeout = senseiConf.getInt(SenseiConfigServletContextListener.SENSEI_CONF_ZKTIMEOUT, zkTimeout);
-    outlierMultiplier = senseiConf.getDouble(SenseiConfigServletContextListener.SENSEI_CONF_ZKTIMEOUT, 3.0);
-    outlierConstant = senseiConf.getDouble(SenseiConfigServletContextListener.SENSEI_CONF_ZKTIMEOUT, 150);
+    outlierMultiplier = senseiConf.getDouble(SenseiConfigServletContextListener.SENSEI_CONF_NC_OUTLIER_MULTIPLIER, 3.0);
+    outlierConstant = senseiConf.getDouble(SenseiConfigServletContextListener.SENSEI_CONF_NC_OUTLIER_CONSTANT, 150);
 
     connectTimeoutMillis = senseiConf.getInt(SenseiConfigServletContextListener.SENSEI_CONF_NC_CONN_TIMEOUT, 1000);
     writeTimeoutMillis = senseiConf.getInt(SenseiConfigServletContextListener.SENSEI_CONF_NC_WRITE_TIMEOUT, 150);

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/AndFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/AndFilterConstructor.java
@@ -52,16 +52,16 @@ public class AndFilterConstructor extends FilterConstructor {
   }
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception
   {
     JSONArray filterArray = (JSONArray)obj;
-    List<Filter> filters = new ArrayList<Filter>(filterArray.length());
+    List<SenseiFilter> filters = new ArrayList<SenseiFilter>(filterArray.length());
     for (int i=0; i<filterArray.length(); ++i)
     {
-      Filter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
+      SenseiFilter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
       if (filter != null)
         filters.add(filter);
     }
-    return new AndFilter(filters);
+    return new SenseiAndFilter(filters);
   }
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/BooleanFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/BooleanFilterConstructor.java
@@ -62,11 +62,11 @@ public class BooleanFilterConstructor extends FilterConstructor
   }
 
   @Override
-  protected Filter doConstructFilter(Object param) throws Exception
+  protected SenseiFilter doConstructFilter(Object param) throws Exception
   {
     JSONObject json = (JSONObject)param;
     Object obj = json.opt(MUST_PARAM);
-    List<Filter> andFilters = new ArrayList<Filter>();
+    List<SenseiFilter> andFilters = new ArrayList<SenseiFilter>();
     if (obj != null)
     {
       if (obj instanceof JSONArray)
@@ -90,29 +90,29 @@ public class BooleanFilterConstructor extends FilterConstructor
         for (int i=0; i<((JSONArray)obj).length(); ++i)
         {
           andFilters.add(
-            new NotFilter(FilterConstructor.constructFilter(((JSONArray)obj).getJSONObject(i),
+            new SenseiNotFilter(FilterConstructor.constructFilter(((JSONArray)obj).getJSONObject(i),
                                                             _qparser)));
         }
       }
       else if (obj instanceof JSONObject)
       {
-        andFilters.add(new NotFilter(FilterConstructor.constructFilter((JSONObject)obj, _qparser)));
+        andFilters.add(new SenseiNotFilter(FilterConstructor.constructFilter((JSONObject)obj, _qparser)));
       }
     }
     JSONArray array = json.optJSONArray(SHOULD_PARAM);
     if (array != null)
     {
-      List<Filter> orFilters = new ArrayList<Filter>(array.length());
+      List<SenseiFilter> orFilters = new ArrayList<SenseiFilter>(array.length());
       for (int i=0; i<array.length(); ++i)
       {
         orFilters.add(FilterConstructor.constructFilter(array.getJSONObject(i), _qparser));
       }
       if (orFilters.size() > 0)
-        andFilters.add(new OrFilter(orFilters));
+        andFilters.add(new SenseiOrFilter(orFilters));
     }
 
     if (andFilters.size() > 0)
-      return new AndFilter(andFilters);
+      return new SenseiAndFilter(andFilters);
     else
       return null;
   }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/ConstExpFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/ConstExpFilterConstructor.java
@@ -18,7 +18,10 @@
  */
 package com.senseidb.search.query.filters;
 
+import com.senseidb.search.query.MatchNoneDocsQuery;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
 import org.json.JSONObject;
@@ -27,17 +30,38 @@ import com.senseidb.search.query.QueryConstructor;
 import com.senseidb.util.JSONUtil.FastJSONArray;
 import com.senseidb.util.JSONUtil.FastJSONObject;
 
+import java.io.IOException;
+
 public class ConstExpFilterConstructor extends FilterConstructor
 {
   public static final String FILTER_TYPE = "const_exp";
 
   @Override
-  protected Filter doConstructFilter(Object json) throws Exception
+  protected SenseiFilter doConstructFilter(Object json) throws Exception
   {
     Query q = QueryConstructor.constructQuery(new FastJSONObject().put(FILTER_TYPE, (JSONObject)json), null);
     if (q == null)
       return null;
-    return new QueryWrapperFilter(q);
-  } 
+
+    final QueryWrapperFilter filter = new QueryWrapperFilter(q);
+
+    if(q instanceof MatchAllDocsQuery) {
+      return new SenseiFilter() {
+        @Override
+        public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+          return new SenseiDocIdSet(filter.getDocIdSet(reader), reader.maxDoc());
+        }
+      };
+    } else if(q instanceof MatchNoneDocsQuery) {
+      return new SenseiFilter() {
+        @Override
+        public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+          return new SenseiDocIdSet(filter.getDocIdSet(reader), 0);
+        }
+      };
+    } else {
+      return SenseiFilter.buildDefault(filter);
+    }
+  }
 
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/CustomFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/CustomFilterConstructor.java
@@ -18,8 +18,11 @@
  */
 package com.senseidb.search.query.filters;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
 import org.json.JSONObject;
+
+import java.io.IOException;
 
 public class CustomFilterConstructor extends FilterConstructor
 {
@@ -33,15 +36,20 @@ public class CustomFilterConstructor extends FilterConstructor
 //  }
   
   @Override
-  protected Filter doConstructFilter(Object json) throws Exception
+  protected SenseiFilter doConstructFilter(Object json) throws Exception
   {
     try
     {
       String className = ((JSONObject)json).getString(CLASS_PARAM);
       Class filterClass = Class.forName(className);
 
-      Filter f = (Filter)filterClass.newInstance();
-      return f;
+      final Filter f = (Filter)filterClass.newInstance();
+
+      if(f instanceof SenseiFilter) {
+        return (SenseiFilter) f;
+      } else {
+        return SenseiFilter.buildDefault(f);
+      }
     }
     catch(Throwable t)
     {

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/FacetSelectionFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/FacetSelectionFilterConstructor.java
@@ -19,10 +19,9 @@
 package com.senseidb.search.query.filters;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
@@ -63,17 +62,16 @@ public class FacetSelectionFilterConstructor extends FilterConstructor{
   
   
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     final JSONObject json = (JSONObject)obj;
-    return new Filter(){
+    return new SenseiFilter(){
 
       @Override
-      public DocIdSet getDocIdSet(IndexReader reader)
-          throws IOException {
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
         if (reader instanceof BoboIndexReader){
           BoboIndexReader boboReader = (BoboIndexReader)reader;
           Iterator<String> iter = json.keys();
-          ArrayList<DocIdSet> docSets = new ArrayList<DocIdSet>();
+          ArrayList<RandomAccessFilter> filters = new ArrayList<RandomAccessFilter>();
           while(iter.hasNext()){
             String key = iter.next();
             FacetHandler facetHandler = boboReader.getFacetHandler(key);
@@ -81,7 +79,7 @@ public class FacetSelectionFilterConstructor extends FilterConstructor{
               try{
                 JSONObject jsonObj = json.getJSONObject(key);
                 BrowseSelection sel = buildFacetSelection(key, jsonObj);
-                docSets.add(facetHandler.buildFilter(sel).getDocIdSet(boboReader));
+                filters.add(facetHandler.buildFilter(sel));
               }
               catch(Exception e){
                 throw new IOException(e.getMessage());
@@ -91,9 +89,15 @@ public class FacetSelectionFilterConstructor extends FilterConstructor{
               throw new IOException(key+" is not defined as a facet handler");
             }
           }
-          if (docSets.size()==0) return null;
-          else if (docSets.size()==1) return docSets.get(0);
-          return new AndDocIdSet(docSets);
+          if(filters.isEmpty()) {
+            return null;
+          } else {
+            List<SenseiFilter> senseiFilters = new ArrayList<SenseiFilter>(filters.size());
+            for(RandomAccessFilter raf : filters) {
+              senseiFilters.add(SenseiFilter.build(raf));
+            }
+            return new SenseiAndFilter(senseiFilters).getSenseiDocIdSet(reader);
+          }
         }
         else{
           throw new IllegalStateException("reader not instance of "+BoboIndexReader.class);

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/FilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/FilterConstructor.java
@@ -100,7 +100,7 @@ public abstract class FilterConstructor {
 		return paramMap;
 	}
 
-	public static Filter constructFilter(JSONObject json, QueryParser qparser) throws Exception
+	public static SenseiFilter constructFilter(JSONObject json, QueryParser qparser) throws Exception
   {
     if (json == null)
       return null;
@@ -118,6 +118,6 @@ public abstract class FilterConstructor {
     return filterConstructor.doConstructFilter(json.get(type));
   }
 	
-	abstract protected Filter doConstructFilter(Object json/* JSONObject or JSONArray */) throws Exception;
+	abstract protected SenseiFilter doConstructFilter(Object json/* JSONObject or JSONArray */) throws Exception;
 
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/OrFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/OrFilterConstructor.java
@@ -49,15 +49,15 @@ public class OrFilterConstructor extends FilterConstructor {
   }
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     JSONArray filterArray = (JSONArray)obj;
-    List<Filter> filters = new ArrayList<Filter>(filterArray.length());
+    List<SenseiFilter> filters = new ArrayList<SenseiFilter>(filterArray.length());
     for (int i=0; i<filterArray.length(); ++i)
     {
-      Filter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
+      SenseiFilter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
       if (filter != null)
         filters.add(filter);
     }
-    return new OrFilter(filters);
+    return new SenseiOrFilter(filters);
   }
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiAndFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiAndFilter.java
@@ -1,0 +1,79 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+
+import com.kamikaze.docidset.impl.AndDocIdSet;
+
+/**
+ * An AND filter.
+ * Currently uses an upper bound of the cardinality estimate by taking the maximum possible number of
+ * documents returned by a sub-filter
+ */
+public class SenseiAndFilter extends SenseiFilter
+{
+
+  private static final long serialVersionUID = 1L;
+
+  private final List<? extends SenseiFilter> _filters;
+
+  public SenseiAndFilter(List<? extends SenseiFilter> filters)
+  {
+    _filters = filters;
+  }
+
+  /**
+   * Returns lowest cardinality sets first.
+   */
+  private static class SenseiDocIdSetComparator implements Comparator<SenseiDocIdSet> {
+    @Override
+    public int compare(SenseiDocIdSet a, SenseiDocIdSet b) {
+      if(a.getCardinalityEstimate() < b.getCardinalityEstimate()) {
+        return -1;
+      } else if(a.getCardinalityEstimate() == b.getCardinalityEstimate()) {
+        return 0;
+      } else {
+        return 1;
+      }
+    }
+  }
+
+  public static final Comparator<SenseiDocIdSet> SENSEI_DOC_ID_SET_COMPARATOR = new SenseiDocIdSetComparator();
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    if (_filters.size() == 1)
+    {
+      return _filters.get(0).getSenseiDocIdSet(reader);
+    }
+    else
+    {
+      List<SenseiDocIdSet> senseiDocIdSets = new ArrayList<SenseiDocIdSet>(_filters.size());
+      int cardinalityEstimate = reader.maxDoc();
+
+      for (SenseiFilter f : _filters)
+      {
+        SenseiDocIdSet senseiDocIdSet = f.getSenseiDocIdSet(reader);
+        senseiDocIdSets.add(senseiDocIdSet);
+        cardinalityEstimate = Math.min(cardinalityEstimate, senseiDocIdSet.getCardinalityEstimate());
+      }
+
+      // Lowest cardinality filters should come first in the AND
+      Collections.sort(senseiDocIdSets, SENSEI_DOC_ID_SET_COMPARATOR);
+
+      List<DocIdSet> docIdSets = new ArrayList<DocIdSet>(senseiDocIdSets.size());
+      for(SenseiDocIdSet senseiDocIdSet : senseiDocIdSets)
+      {
+        docIdSets.add(senseiDocIdSet.getDocIdSet());
+      }
+
+      return new SenseiDocIdSet(new AndDocIdSet(docIdSets), cardinalityEstimate);
+    }
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiFilter.java
@@ -1,0 +1,55 @@
+package com.senseidb.search.query.filters;
+
+import com.browseengine.bobo.api.BoboIndexReader;
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+
+import java.io.IOException;
+
+/**
+ * A filter implementation that provides an expected cardinality of the associated filter.
+ * The cardinality is intended to be used to optimize filter execution order at runtime.
+ * For instance, an AND filter should always begin the AND using a filter of the LOWEST cardinality to
+ * reduce the number of documents considered in the result set
+ */
+public abstract class SenseiFilter extends Filter {
+  @Override
+  public DocIdSet getDocIdSet(IndexReader reader) throws IOException {
+    SenseiDocIdSet docIdSet = getSenseiDocIdSet(reader);
+    return docIdSet.getDocIdSet();
+  }
+
+  public abstract SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException;
+
+  public static SenseiFilter buildDefault(final Filter filter) {
+    return buildDefault(filter, -1);
+  }
+
+  public static SenseiFilter build(final RandomAccessFilter randomAccessFilter) throws IOException {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        double facetSelectivity = randomAccessFilter.getFacetSelectivity((BoboIndexReader) reader);
+        int maxDoc = reader.maxDoc();
+        int cardinality = (int) (facetSelectivity * maxDoc);
+        return new SenseiDocIdSet(randomAccessFilter.getDocIdSet(reader), cardinality);
+      }
+    };
+  }
+
+  public static SenseiFilter buildDefault(final Filter filter, final int suppliedCardinality) {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        // TODO: There needs to be a way to estimate cardinality of a column in general.
+        // Either we can maintain a running estimate of the hit rate of a column
+        // or allow a client to preload an expected estimate
+        int cardinality = suppliedCardinality < 0 ? reader.maxDoc() >> 1 : suppliedCardinality;
+        return new SenseiDocIdSet(filter.getDocIdSet(reader), cardinality);
+      }
+    };
+  }
+
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiNotFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiNotFilter.java
@@ -1,0 +1,34 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+
+import com.kamikaze.docidset.impl.NotDocIdSet;
+
+/**
+ * A NOT filter implementation.
+ *
+ * Since the sensei filters return upper bounds on cardinality, there is no way to estimate the cardinality of
+ * a NOT in general. We would need a lower bound on cardinality to do that. Hence we go with maxDoc
+ */
+public class SenseiNotFilter extends SenseiFilter {
+  private static final long serialVersionUID = 1L;
+
+  private final SenseiFilter _innerFilter;
+
+  public SenseiNotFilter(SenseiFilter innerFilter)
+  {
+    _innerFilter = innerFilter;
+  }
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    SenseiDocIdSet senseiDocIdSet = _innerFilter.getSenseiDocIdSet(reader);
+    int maxDoc = reader.maxDoc();
+//    int cardinality = maxDoc - senseiDocIdSet.getCardinalityEstimate();
+    return new SenseiDocIdSet(new NotDocIdSet(senseiDocIdSet.getDocIdSet(), maxDoc), maxDoc);
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiOrFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiOrFilter.java
@@ -1,0 +1,47 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+
+import com.kamikaze.docidset.impl.OrDocIdSet;
+
+public class SenseiOrFilter extends SenseiFilter {
+  /**
+   *
+   */
+  private static final long serialVersionUID = 1L;
+
+  private final List<? extends SenseiFilter> _filters;
+
+  public SenseiOrFilter(List<? extends SenseiFilter> filters)
+  {
+    _filters = filters;
+  }
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    if(_filters.size() == 1)
+    {
+      return _filters.get(0).getSenseiDocIdSet(reader);
+    }
+    else
+    {
+      List<DocIdSet> list = new ArrayList<DocIdSet>(_filters.size());
+      int cardinalityEstimate = 0;
+      for (SenseiFilter f : _filters)
+      {
+        SenseiDocIdSet senseiDocIdSet = f.getSenseiDocIdSet(reader);
+        list.add(senseiDocIdSet.getDocIdSet());
+        cardinalityEstimate += senseiDocIdSet.getCardinalityEstimate();
+      }
+      cardinalityEstimate = Math.min(cardinalityEstimate, reader.maxDoc());
+      return new SenseiDocIdSet(new OrDocIdSet(list), cardinalityEstimate);
+    }
+  }
+}
+

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/TermFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/TermFilterConstructor.java
@@ -28,7 +28,7 @@ public class TermFilterConstructor extends FilterConstructor{
   public static final String FILTER_TYPE = "term";
 
   @Override
-  protected Filter doConstructFilter(Object param) throws Exception {
+  protected SenseiFilter doConstructFilter(Object param) throws Exception {
     JSONObject json = (JSONObject)param;
 
     Iterator<String> iter = json.keys();

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/TermsFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/TermsFilterConstructor.java
@@ -30,7 +30,7 @@ public class TermsFilterConstructor extends FilterConstructor{
   public static final String FILTER_TYPE = "terms";
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     JSONObject json = (JSONObject)obj;
 
     Iterator<String> iter = json.keys();

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/UIDFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/UIDFilterConstructor.java
@@ -20,6 +20,7 @@ package com.senseidb.search.query.filters;
 
 import java.io.IOException;
 
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
@@ -36,14 +37,13 @@ public class UIDFilterConstructor  extends FilterConstructor{
   public static final String FILTER_TYPE = "ids";
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     final JSONObject json = (JSONObject)obj;
-    return new Filter(){
+    return new SenseiFilter(){
 
       @Override
-      public DocIdSet getDocIdSet(IndexReader reader)
-          throws IOException {
-        if (reader instanceof BoboIndexReader){
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        if (reader instanceof BoboIndexReader) {
           BoboIndexReader boboReader = (BoboIndexReader)reader;
           FacetHandler uidHandler = boboReader.getFacetHandler(SenseiFacetHandlerBuilder.UID_FACET_NAME);
           if (uidHandler!=null && uidHandler instanceof UIDFacetHandler){
@@ -56,7 +56,9 @@ public class UIDFilterConstructor  extends FilterConstructor{
                 uidSel.setValues(vals);
               if (nots != null)
                 uidSel.setNotValues(nots);
-              return uidFacet.buildFilter(uidSel).getDocIdSet(boboReader);
+
+              RandomAccessFilter raf = uidFacet.buildFilter(uidSel);
+              return SenseiDocIdSet.build(raf, boboReader);
             }
             catch(Exception e){
               throw new IOException(e);

--- a/sensei-core/src/main/java/com/senseidb/util/JSONUtil.java
+++ b/sensei-core/src/main/java/com/senseidb/util/JSONUtil.java
@@ -48,6 +48,11 @@ public class JSONUtil
       _inner = new com.alibaba.fastjson.JSONObject();
     }
 
+    public FastJSONObject(int capacity)
+    {
+      _inner = new com.alibaba.fastjson.JSONObject(capacity);
+    }
+
     public FastJSONObject(String str) throws JSONException
     {
       try
@@ -500,6 +505,11 @@ public class JSONUtil
     public FastJSONArray()
     {
       _inner = new com.alibaba.fastjson.JSONArray();
+    }
+
+    public FastJSONArray(int capacity)
+    {
+      _inner = new com.alibaba.fastjson.JSONArray(capacity);
     }
 
     public FastJSONArray(String str) throws JSONException

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiBooleanFilters.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiBooleanFilters.java
@@ -1,0 +1,96 @@
+package com.senseidb.search.query.filters;
+
+import com.kamikaze.docidset.impl.IntArrayDocIdSet;
+import junit.framework.Assert;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSetIterator;
+
+import static org.easymock.classextension.EasyMock.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSenseiBooleanFilters {
+
+  public static SenseiFilter buildFilter(final int... elems) {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        IntArrayDocIdSet docIdSet = new IntArrayDocIdSet(elems.length);
+        for(int elem : elems) {
+          docIdSet.addDoc(elem);
+        }
+
+        return new SenseiDocIdSet(docIdSet, elems.length);
+      }
+    };
+  }
+
+  public static int getCount(DocIdSetIterator iterator) throws IOException {
+    int count = 0;
+    while(iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      count++;
+    }
+    return count;
+  }
+
+  @Test
+  public void testAndFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiAndFilter andFilter = new SenseiAndFilter(filterList);
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(1000);
+
+    replay(indexReader);
+    SenseiDocIdSet senseiDocIdSet = andFilter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(8, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(7, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+  @Test
+  public void testOrFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiOrFilter filter = new SenseiOrFilter(filterList);
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(1000);
+    replay(indexReader);
+
+    SenseiDocIdSet senseiDocIdSet = filter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(18, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(11, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+
+    reset(indexReader);
+    expect(indexReader.maxDoc()).andReturn(15);
+    replay(indexReader);
+
+    senseiDocIdSet = filter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(15, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(11, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+  @Test
+  public void testNotFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiNotFilter filter = new SenseiNotFilter(new SenseiAndFilter(filterList));
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(20).times(2);
+    replay(indexReader);
+
+    SenseiDocIdSet senseiDocIdSet = filter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(20, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(13, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+
+  private List<SenseiFilter> getSenseiFilters() {
+    List<SenseiFilter> filterList = new ArrayList<SenseiFilter>();
+    filterList.add(buildFilter(1, 3, 5, 7, 9, 11, 13, 15, 17, 19));
+    filterList.add(buildFilter(2, 3, 5, 7, 11, 13, 17, 19));
+    return filterList;
+  }
+}

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiTermFilter.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiTermFilter.java
@@ -1,0 +1,89 @@
+package com.senseidb.search.query.filters;
+
+import static org.easymock.classextension.EasyMock.*;
+
+import com.browseengine.bobo.api.BoboIndexReader;
+import com.browseengine.bobo.facets.FacetHandler;
+import com.browseengine.bobo.facets.data.*;
+import com.browseengine.bobo.facets.impl.MultiValueFacetHandler;
+import com.browseengine.bobo.facets.impl.SimpleFacetHandler;
+import com.senseidb.util.Pair;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class TestSenseiTermFilter {
+
+  private String[] vals = new String[]{"a", "c", "e"};
+  private int[] freqs;
+  TermValueList<String> dictionary = new TermStringList();
+
+  @Before
+  public void setup() {
+    dictionary = new TermStringList();
+
+    freqs = new int[27];
+    dictionary.add(null);
+    for(char ch = 'a'; ch <= 'z'; ch++) {
+      dictionary.add("" + ch);
+      freqs[1 + ch - 'a'] = 'z' - ch + 1;
+    }
+  }
+
+  @Test
+  public void testGetValsAndFreqsAndCardinality() {
+
+    List<Pair<String,Integer>> valsAndFreqs = SenseiTermFilter.getValsAndFreqs(vals, dictionary, freqs);
+    Assert.assertEquals("c", valsAndFreqs.get(1).getFirst());
+    Assert.assertEquals(24, valsAndFreqs.get(1).getSecond().intValue());
+
+    int andCardinality = SenseiTermFilter.estimateCardinality(valsAndFreqs, 26, true);
+    int orCardinality = SenseiTermFilter.estimateCardinality(valsAndFreqs, 26, false);
+
+    Assert.assertEquals(22, andCardinality);
+    Assert.assertEquals(26, orCardinality);
+  }
+
+  @Test
+  public void testSenseiTermFilter() throws IOException {
+    String[] vals = new String[]{"a", "c", "e"};
+
+    SenseiTermFilter orTermFilter =
+        new SenseiTermFilter("column", vals, null, false, false);
+
+    BoboIndexReader indexReader = createMock(BoboIndexReader.class);
+
+    MultiValueFacetDataCache facetDataCache =
+        new MultiValueFacetDataCache();
+    facetDataCache.valArray = dictionary;
+    facetDataCache.freqs = freqs;
+
+    FacetHandler facetHandler =
+        new MultiValueFacetHandler("column", 32);
+
+    expect(indexReader.maxDoc()).andReturn(1000).anyTimes();
+    expect(indexReader.getFacetHandler("column")).andReturn(facetHandler);
+    expect(indexReader.getFacetData("column")).andReturn(facetDataCache).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet orDocIdSet = orTermFilter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(26 + 24 + 22, orDocIdSet.getCardinalityEstimate());
+
+    SenseiTermFilter andTermFilter =
+        new SenseiTermFilter("column", vals, null, true, false);
+
+    reset(indexReader);
+    expect(indexReader.maxDoc()).andReturn(1000).anyTimes();
+    expect(indexReader.getFacetHandler("column")).andReturn(facetHandler);
+    expect(indexReader.getFacetData("column")).andReturn(facetDataCache).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet andDocIdSet = andTermFilter.getSenseiDocIdSet(indexReader);
+    Assert.assertEquals(22, andDocIdSet.getCardinalityEstimate());
+  }
+}


### PR DESCRIPTION
Adding the ability for sensei filters to estimate cardinality to optimize filter execution order and traverse fewer documents

I think an optimizer where available would be incredibly useful for the sensei filters. Right now ANDs just execute in whatever order they are given. Executing the lowest cardinality AND first could result in a large performance gain
