### PR TITLE
Added a query planner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ out
 ivy
 logs
 output
+hotspot.log
+derby.log
 lib/test
 lib/master/commons-logging.jar
 lib/master/fastutil.jar
@@ -31,5 +33,6 @@ target
 .idea
 .gradle
 
-
+clients/java/bin
+*/bin
 

--- a/sensei-core/src/main/java/com/senseidb/search/node/impl/DefaultJsonQueryBuilderFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/impl/DefaultJsonQueryBuilderFactory.java
@@ -18,7 +18,10 @@
  */
 package com.senseidb.search.node.impl;
 
+import com.senseidb.search.query.filters.SenseiDocIdSet;
+import com.senseidb.search.query.filters.SenseiFilter;
 import org.apache.log4j.Logger;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.queryParser.QueryParser;
 import org.apache.lucene.search.Filter;
@@ -32,6 +35,8 @@ import com.senseidb.search.query.QueryConstructor;
 import com.senseidb.search.query.filters.FilterConstructor;
 import com.senseidb.util.JSONUtil.FastJSONArray;
 import com.senseidb.util.JSONUtil.FastJSONObject;
+
+import java.io.IOException;
 
 public class DefaultJsonQueryBuilderFactory extends
     AbstractJsonQueryBuilderFactory {
@@ -87,7 +92,21 @@ public class DefaultJsonQueryBuilderFactory extends
       public Filter buildFilter() throws ParseException {
         try
         {
-          return FilterConstructor.constructFilter(filter, _qparser);
+          final SenseiFilter senseiFilter = FilterConstructor.constructFilter(filter, _qparser);
+          return senseiFilter;
+//          return senseiFilter == null ? null : new SenseiFilter() {
+//
+//            volatile boolean called = false;
+//            @Override
+//            public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+//              SenseiDocIdSet docIdSet = senseiFilter.getSenseiDocIdSet(reader);
+//              if(!called) {
+//                logger.info("Running the query: " + (query == null ? "NULL" : query.toString()));
+//                logger.info("Plan(" + reader.maxDoc() + "): " + docIdSet.getQueryPlan());
+//              }
+//              return docIdSet;
+//            }
+//          };
         }
         catch (Exception e)
         {

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/AndFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/AndFilterConstructor.java
@@ -52,16 +52,16 @@ public class AndFilterConstructor extends FilterConstructor {
   }
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception
   {
     JSONArray filterArray = (JSONArray)obj;
-    List<Filter> filters = new ArrayList<Filter>(filterArray.length());
+    List<SenseiFilter> filters = new ArrayList<SenseiFilter>(filterArray.length());
     for (int i=0; i<filterArray.length(); ++i)
     {
-      Filter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
+      SenseiFilter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
       if (filter != null)
         filters.add(filter);
     }
-    return new AndFilter(filters);
+    return new SenseiAndFilter(filters);
   }
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/BooleanFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/BooleanFilterConstructor.java
@@ -62,11 +62,11 @@ public class BooleanFilterConstructor extends FilterConstructor
   }
 
   @Override
-  protected Filter doConstructFilter(Object param) throws Exception
+  protected SenseiFilter doConstructFilter(Object param) throws Exception
   {
     JSONObject json = (JSONObject)param;
     Object obj = json.opt(MUST_PARAM);
-    List<Filter> andFilters = new ArrayList<Filter>();
+    List<SenseiFilter> andFilters = new ArrayList<SenseiFilter>();
     if (obj != null)
     {
       if (obj instanceof JSONArray)
@@ -90,29 +90,29 @@ public class BooleanFilterConstructor extends FilterConstructor
         for (int i=0; i<((JSONArray)obj).length(); ++i)
         {
           andFilters.add(
-            new NotFilter(FilterConstructor.constructFilter(((JSONArray)obj).getJSONObject(i),
+            new SenseiNotFilter(FilterConstructor.constructFilter(((JSONArray)obj).getJSONObject(i),
                                                             _qparser)));
         }
       }
       else if (obj instanceof JSONObject)
       {
-        andFilters.add(new NotFilter(FilterConstructor.constructFilter((JSONObject)obj, _qparser)));
+        andFilters.add(new SenseiNotFilter(FilterConstructor.constructFilter((JSONObject)obj, _qparser)));
       }
     }
     JSONArray array = json.optJSONArray(SHOULD_PARAM);
     if (array != null)
     {
-      List<Filter> orFilters = new ArrayList<Filter>(array.length());
+      List<SenseiFilter> orFilters = new ArrayList<SenseiFilter>(array.length());
       for (int i=0; i<array.length(); ++i)
       {
         orFilters.add(FilterConstructor.constructFilter(array.getJSONObject(i), _qparser));
       }
       if (orFilters.size() > 0)
-        andFilters.add(new OrFilter(orFilters));
+        andFilters.add(new SenseiOrFilter(orFilters));
     }
 
     if (andFilters.size() > 0)
-      return new AndFilter(andFilters);
+      return new SenseiAndFilter(andFilters);
     else
       return null;
   }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/CustomFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/CustomFilterConstructor.java
@@ -18,8 +18,11 @@
  */
 package com.senseidb.search.query.filters;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Filter;
 import org.json.JSONObject;
+
+import java.io.IOException;
 
 public class CustomFilterConstructor extends FilterConstructor
 {
@@ -33,15 +36,20 @@ public class CustomFilterConstructor extends FilterConstructor
 //  }
   
   @Override
-  protected Filter doConstructFilter(Object json) throws Exception
+  protected SenseiFilter doConstructFilter(Object json) throws Exception
   {
     try
     {
       String className = ((JSONObject)json).getString(CLASS_PARAM);
       Class filterClass = Class.forName(className);
 
-      Filter f = (Filter)filterClass.newInstance();
-      return f;
+      final Filter f = (Filter)filterClass.newInstance();
+
+      if(f instanceof SenseiFilter) {
+        return (SenseiFilter) f;
+      } else {
+        return SenseiFilter.buildDefault(f);
+      }
     }
     catch(Throwable t)
     {

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/DocIdSetCardinality.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/DocIdSetCardinality.java
@@ -1,0 +1,92 @@
+package com.senseidb.search.query.filters;
+
+/**
+ * Estimated cardinality of a DocIdSet.
+ *
+ * We represent estimated cardinality with an uniform distribution from min to
+ * max, where 0 is no documents, and 1.0 is all documents.
+*/
+public class DocIdSetCardinality
+    implements Cloneable, Comparable<DocIdSetCardinality> {
+
+  double min;
+  double max;
+
+  public static DocIdSetCardinality zero() {
+    return new DocIdSetCardinality(0.0, 0.0);
+  }
+
+  public static DocIdSetCardinality one() {
+    return new DocIdSetCardinality(1.0, 1.0);
+  }
+
+  public static DocIdSetCardinality random() {
+    return new DocIdSetCardinality(0.0, 1.0);
+  }
+
+  public static DocIdSetCardinality exact(double cardinality) {
+    return new DocIdSetCardinality(cardinality, cardinality);
+  }
+
+  public static DocIdSetCardinality exact(int count, int outOf) {
+    return exact(((double)count) / outOf);
+  }
+
+  public static DocIdSetCardinality exactRange(int min, int max, int outOf) {
+    return new DocIdSetCardinality(((double)min) / outOf, ((double)max) / outOf);
+  }
+
+  public static DocIdSetCardinality exactRange(double min, double max) {
+    return new DocIdSetCardinality(min, max);
+  }
+
+  DocIdSetCardinality(double minCardinality, double maxCardinality) {
+    min = Math.min(Math.max(0.0, minCardinality), 1.0);
+    max = Math.min(Math.max(0.0, maxCardinality), 1.0);
+  }
+
+  public void andWith(DocIdSetCardinality other) {
+    min = Math.max(0.0, min + other.min - 1.0);
+    max = Math.min(max, other.max);
+  }
+
+  public void orWith(DocIdSetCardinality other) {
+    min = Math.max(min, other.min);
+    max = Math.min(1.0, max + other.max);
+  }
+
+  public void invert() {
+    final double oldMin = min;
+    min = 1.0 - max;
+    max = 1.0 - oldMin;
+  }
+
+  public boolean isOne() {
+    return min >= 1.0 && max >= 1.0;
+  }
+
+  public boolean isZero() {
+    return min <= 0.0 && max <= 0.0;
+  }
+
+  public boolean isRandom() {
+    return min <= 0.0 && max >= 1.0;
+  }
+
+  @Override public String toString() {
+    return min + "-" + max;
+  }
+
+  @Override public DocIdSetCardinality clone() {
+    try {
+      return (DocIdSetCardinality)super.clone();
+    } catch (CloneNotSupportedException e) {
+      return null;
+    }
+  }
+
+  // Compare averages: (min + max) / 2, same as comparing min + max
+  @Override public int compareTo(DocIdSetCardinality o) {
+    return (int)Math.signum(min + max - o.min - o.max);
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/FilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/FilterConstructor.java
@@ -100,7 +100,7 @@ public abstract class FilterConstructor {
 		return paramMap;
 	}
 
-	public static Filter constructFilter(JSONObject json, QueryParser qparser) throws Exception
+	public static SenseiFilter constructFilter(JSONObject json, QueryParser qparser) throws Exception
   {
     if (json == null)
       return null;
@@ -118,6 +118,6 @@ public abstract class FilterConstructor {
     return filterConstructor.doConstructFilter(json.get(type));
   }
 	
-	abstract protected Filter doConstructFilter(Object json/* JSONObject or JSONArray */) throws Exception;
+	abstract protected SenseiFilter doConstructFilter(Object json/* JSONObject or JSONArray */) throws Exception;
 
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/OrFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/OrFilterConstructor.java
@@ -49,15 +49,15 @@ public class OrFilterConstructor extends FilterConstructor {
   }
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     JSONArray filterArray = (JSONArray)obj;
-    List<Filter> filters = new ArrayList<Filter>(filterArray.length());
+    List<SenseiFilter> filters = new ArrayList<SenseiFilter>(filterArray.length());
     for (int i=0; i<filterArray.length(); ++i)
     {
-      Filter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
+      SenseiFilter filter = FilterConstructor.constructFilter(filterArray.getJSONObject(i), _qparser);
       if (filter != null)
         filters.add(filter);
     }
-    return new OrFilter(filters);
+    return new SenseiOrFilter(filters);
   }
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/PathFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/PathFilterConstructor.java
@@ -21,10 +21,10 @@ package com.senseidb.search.query.filters;
 import java.io.IOException;
 import java.util.Iterator;
 
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Filter;
 import org.json.JSONObject;
 
 import com.browseengine.bobo.api.BoboIndexReader;
@@ -39,7 +39,7 @@ public class PathFilterConstructor extends FilterConstructor
   public static final String FILTER_TYPE = "path";
 
   @Override
-  protected Filter doConstructFilter(Object param) throws Exception
+  protected SenseiFilter doConstructFilter(Object param) throws Exception
   {
     JSONObject json = (JSONObject)param;
 
@@ -66,11 +66,10 @@ public class PathFilterConstructor extends FilterConstructor
       strict = false;
     }
 
-    return new Filter()
+    return new SenseiFilter()
     {
       @Override
-      public DocIdSet getDocIdSet(final IndexReader reader) throws IOException
-      {
+      public SenseiDocIdSet getSenseiDocIdSet(final IndexReader reader) throws IOException {
         if (reader instanceof BoboIndexReader)
         {
           BoboIndexReader boboReader = (BoboIndexReader)reader;
@@ -81,23 +80,24 @@ public class PathFilterConstructor extends FilterConstructor
             sel.setValues(new String[]{path});
             sel.setSelectionProperty(PathFacetHandler.SEL_PROP_NAME_DEPTH, String.valueOf(depth));
             sel.setSelectionProperty(PathFacetHandler.SEL_PROP_NAME_STRICT, String.valueOf(strict));
-            Filter filter = ((PathFacetHandler)facetHandler).buildFilter(sel);
-            if (filter == null)
-              return new DocIdSet()
-              {
+            RandomAccessFilter filter = ((PathFacetHandler)facetHandler).buildFilter(sel);
+            if (filter == null) {
+
+              DocIdSet docIdSet = new DocIdSet() {
                 @Override
-                public boolean isCacheable()
-                {
+                public boolean isCacheable() {
                   return false;
                 }
 
                 @Override
-                public DocIdSetIterator iterator() throws IOException
-                {
+                public DocIdSetIterator iterator() throws IOException {
                   return new MatchAllDocIdSetIterator(reader);
                 }
               };
-            return filter.getDocIdSet(reader);
+              int maxDoc = reader.maxDoc();
+              return new SenseiDocIdSet(docIdSet, DocIdSetCardinality.one(), "ALL");
+            }
+            return SenseiDocIdSet.build(filter, boboReader, "PATH " + field);
           }
         }
 

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/QueryFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/QueryFilterConstructor.java
@@ -18,13 +18,15 @@
  */
 package com.senseidb.search.query.filters;
 
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryParser.QueryParser;
-import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
 import org.json.JSONObject;
 
 import com.senseidb.search.query.QueryConstructor;
+
+import java.io.IOException;
 
 public class QueryFilterConstructor extends FilterConstructor{
   public static final String FILTER_TYPE = "query";
@@ -37,11 +39,19 @@ public class QueryFilterConstructor extends FilterConstructor{
   }
 
 	@Override
-	protected Filter doConstructFilter(Object json) throws Exception {
-		Query q = QueryConstructor.constructQuery((JSONObject)json, _qparser);
+	protected SenseiFilter doConstructFilter(Object json) throws Exception {
+		final Query q = QueryConstructor.constructQuery((JSONObject)json, _qparser);
+
     if (q == null)
       return null;
-		return new QueryWrapperFilter(q);
+
+    final QueryWrapperFilter queryWrapperFilter = new QueryWrapperFilter(q);
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        return new SenseiDocIdSet(queryWrapperFilter.getDocIdSet(reader), DocIdSetCardinality.random(), "QUERY <" + q.toString() + ">");
+      }
+    };
 	}
 	
 }

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiAndFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiAndFilter.java
@@ -1,0 +1,77 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+
+import com.kamikaze.docidset.impl.AndDocIdSet;
+
+/**
+ * An AND filter.
+ * Currently uses an upper bound of the cardinality estimate by taking the maximum possible number of
+ * documents returned by a sub-filter
+ */
+public class SenseiAndFilter extends SenseiFilter
+{
+  private static final long serialVersionUID = 1L;
+
+  private final List<? extends SenseiFilter> _filters;
+
+  public SenseiAndFilter(List<? extends SenseiFilter> filters)
+  {
+    _filters = filters;
+  }
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    if (_filters.size() == 1)
+    {
+      return _filters.get(0).getSenseiDocIdSet(reader);
+    }
+    else
+    {
+      List<SenseiDocIdSet> senseiDocIdSets = new ArrayList<SenseiDocIdSet>(_filters.size());
+      DocIdSetCardinality totalDocIdSetCardinalityEstimate = DocIdSetCardinality.one();
+
+      for (SenseiFilter f : _filters)
+      {
+        SenseiDocIdSet senseiDocIdSet = f.getSenseiDocIdSet(reader);
+        senseiDocIdSets.add(senseiDocIdSet);
+        totalDocIdSetCardinalityEstimate.andWith(senseiDocIdSet.getCardinalityEstimate());
+      }
+
+      // Lowest cardinality filters should come first in AND
+      Collections.sort(senseiDocIdSets, SenseiDocIdSet.INCREASING_CARDINALITY_COMPARATOR);
+
+      // @todo(nsabovic): If we detect totalCardinality of 0/1, we should insert match all/none filter.
+
+      List<DocIdSet> docIdSets = new ArrayList<DocIdSet>(senseiDocIdSets.size());
+      StringBuilder queryPlan = new StringBuilder("AND(");
+      for(SenseiDocIdSet senseiDocIdSet : senseiDocIdSets)
+      {
+        if (senseiDocIdSet != senseiDocIdSets.get(0)) {
+          queryPlan.append(", ");
+        }
+
+        if (!senseiDocIdSet.getCardinalityEstimate().isOne()) {
+          docIdSets.add(senseiDocIdSet.getDocIdSet());
+        } else {
+          queryPlan.append("SKIPPED ");
+        }
+        queryPlan.append(senseiDocIdSet.getQueryPlan());
+      }
+      queryPlan.append(")");
+
+      if (docIdSets.size() == 1) {
+        return new SenseiDocIdSet(docIdSets.get(0), totalDocIdSetCardinalityEstimate, "TRIVIAL " + queryPlan.toString());
+      } else {
+        return new SenseiDocIdSet(new AndDocIdSet(docIdSets), totalDocIdSetCardinalityEstimate, queryPlan.toString());
+      }
+    }
+  }
+
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiDocIdSet.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiDocIdSet.java
@@ -1,0 +1,51 @@
+package com.senseidb.search.query.filters;
+
+import com.browseengine.bobo.api.BoboIndexReader;
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
+import org.apache.lucene.search.DocIdSet;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+public class SenseiDocIdSet {
+  public static final Comparator<SenseiDocIdSet> DECREASING_CARDINALITY_COMPARATOR = new Comparator<SenseiDocIdSet>() {
+    @Override
+    public int compare(SenseiDocIdSet a, SenseiDocIdSet b) {
+      return -a.getCardinalityEstimate().compareTo(b.getCardinalityEstimate());
+    }
+  };
+  public static final Comparator<SenseiDocIdSet> INCREASING_CARDINALITY_COMPARATOR = new Comparator<SenseiDocIdSet> (){
+    @Override
+    public int compare(SenseiDocIdSet a, SenseiDocIdSet b) {
+      return a.getCardinalityEstimate().compareTo(b.getCardinalityEstimate());
+    }
+  };
+
+  private final DocIdSet docIdSet;
+  private final DocIdSetCardinality docIdSetCardinalityEstimate;
+  private final String queryPlan;
+
+  public SenseiDocIdSet(DocIdSet docIdSet, DocIdSetCardinality docIdSetCardinalityEstimate, String queryPlan) {
+    this.docIdSet = docIdSet;
+    this.docIdSetCardinalityEstimate = docIdSetCardinalityEstimate;
+    this.queryPlan = "[" + docIdSetCardinalityEstimate + "] " + queryPlan;
+  }
+
+  public DocIdSet getDocIdSet() {
+    return docIdSet;
+  }
+
+  public DocIdSetCardinality getCardinalityEstimate() {
+    return docIdSetCardinalityEstimate;
+  }
+
+  public String getQueryPlan() {
+    return queryPlan;
+  }
+
+  public static SenseiDocIdSet build(RandomAccessFilter randomAccessFilter, BoboIndexReader boboIndexReader, String queryPlan) throws IOException {
+    DocIdSet docIdSet = randomAccessFilter.getDocIdSet(boboIndexReader);
+    double facetSelectivity = randomAccessFilter.getFacetSelectivity(boboIndexReader);
+    return new SenseiDocIdSet(docIdSet, DocIdSetCardinality.exact(facetSelectivity), queryPlan);
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiFilter.java
@@ -1,0 +1,53 @@
+package com.senseidb.search.query.filters;
+
+import com.browseengine.bobo.api.BoboIndexReader;
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+
+import java.io.IOException;
+
+/**
+ * A filter implementation that provides an expected cardinality of the associated filter.
+ * The cardinality is intended to be used to optimize filter execution order at runtime.
+ * For instance, an AND filter should always begin the AND using a filter of the LOWEST cardinality to
+ * reduce the number of documents considered in the result set
+ */
+public abstract class SenseiFilter extends Filter {
+  @Override
+  public DocIdSet getDocIdSet(IndexReader reader) throws IOException {
+    SenseiDocIdSet docIdSet = getSenseiDocIdSet(reader);
+    return docIdSet.getDocIdSet();
+  }
+
+  public abstract SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException;
+
+  public static SenseiFilter buildDefault(final Filter filter) {
+    return buildDefault(filter, null, "UNKNOWN LUCENE FILTER");
+  }
+
+  public static SenseiFilter build(final RandomAccessFilter randomAccessFilter, final String queryPlan) throws IOException {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        double facetSelectivity = randomAccessFilter.getFacetSelectivity((BoboIndexReader) reader);
+        return new SenseiDocIdSet(randomAccessFilter.getDocIdSet(reader), DocIdSetCardinality.exact(facetSelectivity), queryPlan);
+      }
+    };
+  }
+
+  public static SenseiFilter buildDefault(final Filter filter, final DocIdSetCardinality suppliedDocIdSetCardinality, final String queryPlan) {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        // TODO: There needs to be a way to estimate docIdSetCardinality of a column in general.
+        // Either we can maintain a running estimate of the hit rate of a column
+        // or allow a client to preload an expected estimate
+        DocIdSetCardinality docIdSetCardinality = suppliedDocIdSetCardinality == null ? DocIdSetCardinality.random() : suppliedDocIdSetCardinality;
+        return new SenseiDocIdSet(filter.getDocIdSet(reader), docIdSetCardinality, queryPlan);
+      }
+    };
+  }
+
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiNotFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiNotFilter.java
@@ -1,0 +1,33 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.IndexReader;
+
+import com.kamikaze.docidset.impl.NotDocIdSet;
+
+/**
+ * A NOT filter implementation.
+ *
+ * Since the sensei filters return upper bounds on cardinality, there is no way to estimate the cardinality of
+ * a NOT in general. We would need a lower bound on cardinality to do that. Hence we go with maxDoc
+ */
+public class SenseiNotFilter extends SenseiFilter {
+  private static final long serialVersionUID = 1L;
+
+  private final SenseiFilter _innerFilter;
+
+  public SenseiNotFilter(SenseiFilter innerFilter)
+  {
+    _innerFilter = innerFilter;
+  }
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    SenseiDocIdSet senseiDocIdSet = _innerFilter.getSenseiDocIdSet(reader);
+    int maxDoc = reader.maxDoc();
+    DocIdSetCardinality docIdSetCardinality = senseiDocIdSet.getCardinalityEstimate().clone();
+    docIdSetCardinality.invert();
+    return new SenseiDocIdSet(new NotDocIdSet(senseiDocIdSet.getDocIdSet(), maxDoc), docIdSetCardinality, "NOT " + senseiDocIdSet.getQueryPlan());
+  }
+}

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiOrFilter.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/SenseiOrFilter.java
@@ -1,0 +1,73 @@
+package com.senseidb.search.query.filters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSet;
+
+import com.kamikaze.docidset.impl.OrDocIdSet;
+
+public class SenseiOrFilter extends SenseiFilter {
+  private static final long serialVersionUID = 1L;
+
+  private final List<? extends SenseiFilter> _filters;
+
+
+  public SenseiOrFilter(List<? extends SenseiFilter> filters)
+  {
+    _filters = filters;
+  }
+
+  @Override
+  public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+    if(_filters.size() == 1)
+    {
+      return _filters.get(0).getSenseiDocIdSet(reader);
+    }
+    else
+    {
+      List<SenseiDocIdSet> senseiDocIdSets = new ArrayList<SenseiDocIdSet>(_filters.size());
+      DocIdSetCardinality totalDocIdSetCardinalityEstimate = DocIdSetCardinality.zero();
+
+      for (SenseiFilter f : _filters)
+      {
+        SenseiDocIdSet senseiDocIdSet = f.getSenseiDocIdSet(reader);
+        senseiDocIdSets.add(senseiDocIdSet);
+        totalDocIdSetCardinalityEstimate.orWith(senseiDocIdSet.getCardinalityEstimate());
+      }
+
+      // Highest cardinality filters should come first in OR
+      Collections.sort(senseiDocIdSets, SenseiDocIdSet.DECREASING_CARDINALITY_COMPARATOR);
+
+
+      // @todo(nsabovic): If we detect totalCardinality of 0/1, we should insert match all/none filter.
+
+      List<DocIdSet> docIdSets = new ArrayList<DocIdSet>(senseiDocIdSets.size());
+      StringBuilder queryPlan = new StringBuilder("OR(");
+      for(SenseiDocIdSet senseiDocIdSet : senseiDocIdSets)
+      {
+        if (senseiDocIdSet != senseiDocIdSets.get(0)) {
+          queryPlan.append(", ");
+        }
+        if (!senseiDocIdSet.getCardinalityEstimate().isZero()) {
+          docIdSets.add(senseiDocIdSet.getDocIdSet());
+        } else {
+          queryPlan.append("SKIPPED ");
+        }
+        queryPlan.append(senseiDocIdSet.getQueryPlan());
+      }
+      queryPlan.append(")");
+
+
+      if (docIdSets.size() == 1) {
+        return new SenseiDocIdSet(docIdSets.get(0), totalDocIdSetCardinalityEstimate, "TRIVIAL " + queryPlan.toString());
+      } else {
+        return new SenseiDocIdSet(new OrDocIdSet(docIdSets), totalDocIdSetCardinalityEstimate, queryPlan.toString());
+      }
+    }
+  }
+}
+

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/TermFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/TermFilterConstructor.java
@@ -28,7 +28,7 @@ public class TermFilterConstructor extends FilterConstructor{
   public static final String FILTER_TYPE = "term";
 
   @Override
-  protected Filter doConstructFilter(Object param) throws Exception {
+  protected SenseiFilter doConstructFilter(Object param) throws Exception {
     JSONObject json = (JSONObject)param;
 
     Iterator<String> iter = json.keys();

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/TermsFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/TermsFilterConstructor.java
@@ -30,7 +30,7 @@ public class TermsFilterConstructor extends FilterConstructor{
   public static final String FILTER_TYPE = "terms";
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     JSONObject json = (JSONObject)obj;
 
     Iterator<String> iter = json.keys();

--- a/sensei-core/src/main/java/com/senseidb/search/query/filters/UIDFilterConstructor.java
+++ b/sensei-core/src/main/java/com/senseidb/search/query/filters/UIDFilterConstructor.java
@@ -20,6 +20,8 @@ package com.senseidb.search.query.filters;
 
 import java.io.IOException;
 
+import com.browseengine.bobo.facets.filter.RandomAccessFilter;
+import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.Filter;
@@ -36,14 +38,13 @@ public class UIDFilterConstructor  extends FilterConstructor{
   public static final String FILTER_TYPE = "ids";
 
   @Override
-  protected Filter doConstructFilter(Object obj) throws Exception {
+  protected SenseiFilter doConstructFilter(Object obj) throws Exception {
     final JSONObject json = (JSONObject)obj;
-    return new Filter(){
+    return new SenseiFilter(){
 
       @Override
-      public DocIdSet getDocIdSet(IndexReader reader)
-          throws IOException {
-        if (reader instanceof BoboIndexReader){
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        if (reader instanceof BoboIndexReader) {
           BoboIndexReader boboReader = (BoboIndexReader)reader;
           FacetHandler uidHandler = boboReader.getFacetHandler(SenseiFacetHandlerBuilder.UID_FACET_NAME);
           if (uidHandler!=null && uidHandler instanceof UIDFacetHandler){
@@ -56,7 +57,9 @@ public class UIDFilterConstructor  extends FilterConstructor{
                 uidSel.setValues(vals);
               if (nots != null)
                 uidSel.setNotValues(nots);
-              return uidFacet.buildFilter(uidSel).getDocIdSet(boboReader);
+
+              RandomAccessFilter raf = uidFacet.buildFilter(uidSel);
+              return SenseiDocIdSet.build(raf, boboReader, "<uid> IN <" + StringUtils.join(vals, ", ") + "> NOT IN <" + StringUtils.join(nots, ", ") + ">");
             }
             catch(Exception e){
               throw new IOException(e);

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/DocSetAssertions.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/DocSetAssertions.java
@@ -1,0 +1,16 @@
+package com.senseidb.search.query.filters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DocSetAssertions {
+  static void assertRange(int min, int max, int maxDoc, DocIdSetCardinality c) {
+    assertEquals("Lower bound", min, c.min * maxDoc, 1.0);
+    assertEquals("Upper bound", max, c.max * maxDoc, 1.0);
+  }
+
+  static public void assertRange(double min, double max, DocIdSetCardinality c) {
+    assertEquals("Lower bound", min, c.min, 0.0001);
+    assertEquals("Upper bound", max, c.max, 0.0001);
+  }
+}

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/TestDocIdSetCardinality.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/TestDocIdSetCardinality.java
@@ -1,0 +1,48 @@
+package com.senseidb.search.query.filters;
+
+import org.junit.Test;
+
+public class TestDocIdSetCardinality {
+  @Test
+  public void testConstants() {
+    DocIdSetCardinality c;
+    DocSetAssertions.assertRange(0.0, 0.0, DocIdSetCardinality.zero());
+    DocSetAssertions.assertRange(1.0, 1.0, DocIdSetCardinality.one());
+    DocSetAssertions.assertRange(0.0, 1.0, DocIdSetCardinality.random());
+    DocSetAssertions.assertRange(0.5, 0.5, DocIdSetCardinality.exact(.5));
+    DocSetAssertions.assertRange(0.5, 0.5, DocIdSetCardinality.exact(5, 10));
+  }
+
+  @Test
+  public void testAnds() {
+    DocIdSetCardinality c;
+    c = new DocIdSetCardinality(0.1, 0.9);
+    c.andWith(new DocIdSetCardinality(0.1, 0.9));
+    DocSetAssertions.assertRange(0, 0.9, c);
+
+    c = new DocIdSetCardinality(0.8, 0.9);
+    c.andWith(new DocIdSetCardinality(0.8, 0.9));
+    DocSetAssertions.assertRange(0.6, 0.9, c);
+  }
+
+  @Test
+  public void testOrs() {
+    DocIdSetCardinality c;
+    c = new DocIdSetCardinality(0.1, 0.2);
+    c.orWith(new DocIdSetCardinality(0.1, 0.2));
+    DocSetAssertions.assertRange(0.1, 0.4, c);
+
+    c = new DocIdSetCardinality(0.8, 0.9);
+    c.orWith(new DocIdSetCardinality(0.8, 0.9));
+    DocSetAssertions.assertRange(0.8, 1.0, c);
+  }
+
+  @Test
+  public void testNot() {
+    DocIdSetCardinality c;
+    c = new DocIdSetCardinality(0.1, 0.2);
+    c.invert();
+    DocSetAssertions.assertRange(0.8, 0.9, c);
+  }
+
+}

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiBooleanFilters.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiBooleanFilters.java
@@ -1,0 +1,88 @@
+package com.senseidb.search.query.filters;
+
+import com.kamikaze.docidset.impl.IntArrayDocIdSet;
+import junit.framework.Assert;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.DocIdSetIterator;
+
+import static org.easymock.classextension.EasyMock.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSenseiBooleanFilters {
+
+  public static SenseiFilter buildFilter(final int... elems) {
+    return new SenseiFilter() {
+      @Override
+      public SenseiDocIdSet getSenseiDocIdSet(IndexReader reader) throws IOException {
+        IntArrayDocIdSet docIdSet = new IntArrayDocIdSet(elems.length);
+        for(int elem : elems) {
+          docIdSet.addDoc(elem);
+        }
+
+        return new SenseiDocIdSet(docIdSet, DocIdSetCardinality.exact(elems.length, reader.maxDoc()), "IntArray[" + elems.length + "]");
+      }
+    };
+  }
+
+  public static int getCount(DocIdSetIterator iterator) throws IOException {
+    int count = 0;
+    while(iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      count++;
+    }
+    return count;
+  }
+
+  @Test
+  public void testAndFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiAndFilter andFilter = new SenseiAndFilter(filterList);
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(20).anyTimes();
+
+    replay(indexReader);
+    SenseiDocIdSet senseiDocIdSet = andFilter.getSenseiDocIdSet(indexReader);
+    DocSetAssertions.assertRange(9, 14, 20, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(14, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+  @Test
+  public void testOrFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiOrFilter filter = new SenseiOrFilter(filterList);
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(20).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet senseiDocIdSet = filter.getSenseiDocIdSet(indexReader);
+    DocSetAssertions.assertRange(15, 20, 20, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(15, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+  @Test
+  public void testNotFilter() throws IOException {
+    List<SenseiFilter> filterList = getSenseiFilters();
+    SenseiNotFilter filter = new SenseiNotFilter(new SenseiAndFilter(filterList));
+
+    IndexReader indexReader = createMock(IndexReader.class);
+    expect(indexReader.maxDoc()).andReturn(20).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet senseiDocIdSet = filter.getSenseiDocIdSet(indexReader);
+    DocSetAssertions.assertRange(6, 11, 20, senseiDocIdSet.getCardinalityEstimate());
+    Assert.assertEquals(6, getCount(senseiDocIdSet.getDocIdSet().iterator()));
+  }
+
+
+  private List<SenseiFilter> getSenseiFilters() {
+    List<SenseiFilter> filterList = new ArrayList<SenseiFilter>();
+    filterList.add(buildFilter(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19)); // 15 elements
+    filterList.add(buildFilter(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 17, 19));     // 14 elements
+    return filterList;
+  }
+}

--- a/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiTermFilter.java
+++ b/sensei-core/src/test/java/com/senseidb/search/query/filters/TestSenseiTermFilter.java
@@ -1,0 +1,83 @@
+package com.senseidb.search.query.filters;
+
+import static org.easymock.classextension.EasyMock.*;
+import static org.junit.Assert.*;
+
+import com.browseengine.bobo.api.BoboIndexReader;
+import com.browseengine.bobo.facets.FacetHandler;
+import com.browseengine.bobo.facets.data.*;
+import com.browseengine.bobo.facets.impl.MultiValueFacetHandler;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TestSenseiTermFilter {
+
+  private String[] vals = new String[]{"a", "c", "e"};
+  private int[] freqs;
+  TermValueList<String> dictionary = new TermStringList();
+
+  @Before
+  public void setup() {
+    dictionary = new TermStringList();
+
+    freqs = new int[27];
+    dictionary.add(null);
+    for(char ch = 'a'; ch <= 'z'; ch++) {
+      dictionary.add("" + ch);
+      freqs[1 + ch - 'a'] = 'z' - ch + 1;
+    }
+  }
+
+
+  @Test
+  public void testGetValsByFrequency() {
+
+    DocIdSetCardinality andCardinality = DocIdSetCardinality.one();
+    String andVals[] = SenseiTermFilter.getValsByFrequency(vals, freqs, 26, andCardinality, dictionary, true);
+    assertArrayEquals(andVals, new String[]{"e", "c", "a"});
+    DocSetAssertions.assertRange(20, 22, 26, andCardinality);
+
+    DocIdSetCardinality orCardinality = DocIdSetCardinality.zero();
+    String orgVals[] = SenseiTermFilter.getValsByFrequency(vals, freqs, 26, orCardinality, dictionary, false);
+    assertArrayEquals(orgVals, new String[]{"a", "c", "e"});
+    DocSetAssertions.assertRange(26, 26, 26, orCardinality);
+  }
+
+  @Test
+  public void testSenseiTermFilter() throws IOException {
+    SenseiTermFilter orTermFilter =
+        new SenseiTermFilter("column", vals, null, false, false);
+
+    BoboIndexReader indexReader = createMock(BoboIndexReader.class);
+
+    MultiValueFacetDataCache facetDataCache =
+        new MultiValueFacetDataCache();
+    facetDataCache.valArray = dictionary;
+    facetDataCache.freqs = freqs;
+
+    FacetHandler facetHandler =
+        new MultiValueFacetHandler("column", 32);
+
+    expect(indexReader.maxDoc()).andReturn(1000).anyTimes();
+    expect(indexReader.getFacetHandler("column")).andReturn(facetHandler);
+    expect(indexReader.getFacetData("column")).andReturn(facetDataCache).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet orDocIdSet = orTermFilter.getSenseiDocIdSet(indexReader);
+    DocSetAssertions.assertRange(26, 72, 1000, orDocIdSet.getCardinalityEstimate());
+
+    SenseiTermFilter andTermFilter =
+        new SenseiTermFilter("column", vals, null, true, false);
+
+    reset(indexReader);
+    expect(indexReader.maxDoc()).andReturn(1000).anyTimes();
+    expect(indexReader.getFacetHandler("column")).andReturn(facetHandler);
+    expect(indexReader.getFacetData("column")).andReturn(facetDataCache).anyTimes();
+    replay(indexReader);
+
+    SenseiDocIdSet andDocIdSet = andTermFilter.getSenseiDocIdSet(indexReader);
+    DocSetAssertions.assertRange(0, 22, 1000, andDocIdSet.getCardinalityEstimate());
+  }
+}


### PR DESCRIPTION
Added the ability to show the actual query plan during execution. Currently requires uncommenting some code, because logging query plans is expensive.
Sensei filters learned to estimate cardinality in order to optimize filter execution order and traverse fewer documents. Specifically, this info is used during ANDs, ORs, and term searches that use facet cache. For ANDs, filters are rearranged so that the lowest-cardinality filters come first, and always-true filters are dropped. For ORs, highest cardinality filters come first, and always-false filters are dropped. Cardinality is tracked as a range (as opposed to Bobo's single-number selectivity), which gives a bit more accurate results.
