### PR TITLE
Adding back the Old Api without the Searchable for the QueryBuilderFacto...

### DIFF
--- a/sensei-core/src/main/java/com/senseidb/search/node/SenseiQueryBuilderFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/SenseiQueryBuilderFactory.java
@@ -23,5 +23,6 @@ import org.apache.lucene.search.Searchable;
 
 public interface SenseiQueryBuilderFactory
 {
+  SenseiQueryBuilder getQueryBuilder(SenseiQuery query) throws Exception;
   SenseiQueryBuilder getQueryBuilder(SenseiQuery query, Searchable searchable) throws Exception;
 }

--- a/sensei-core/src/main/java/com/senseidb/search/node/impl/AbstractJsonQueryBuilderFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/impl/AbstractJsonQueryBuilderFactory.java
@@ -43,6 +43,17 @@ public abstract class AbstractJsonQueryBuilderFactory implements
 		return buildQueryBuilder(jsonQuery, searchable);
 	}
 
+  public SenseiQueryBuilder getQueryBuilder(SenseiQuery query)
+      throws Exception {
+    JSONObject jsonQuery = null;
+    String queryString = query == null ? null : query.toString();
+    if (!StringUtils.isEmpty(queryString)){
+      jsonQuery = new FastJSONObject(queryString);
+    }
+    return buildQueryBuilder(jsonQuery, null);
+  }
+
 	public abstract SenseiQueryBuilder buildQueryBuilder(JSONObject jsonQuery, Searchable searchable);
+	public abstract SenseiQueryBuilder buildQueryBuilder(JSONObject jsonQuery);
 
 }

--- a/sensei-core/src/main/java/com/senseidb/search/node/impl/DefaultJsonQueryBuilderFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/impl/DefaultJsonQueryBuilderFactory.java
@@ -165,4 +165,9 @@ public class DefaultJsonQueryBuilderFactory extends
 
     };
   }
+
+  @Override
+  public SenseiQueryBuilder buildQueryBuilder(JSONObject jsonQuery) {
+    return buildQueryBuilder(jsonQuery, null);
+  }
 }

--- a/sensei-core/src/main/java/com/senseidb/search/node/impl/SimpleQueryBuilderFactory.java
+++ b/sensei-core/src/main/java/com/senseidb/search/node/impl/SimpleQueryBuilderFactory.java
@@ -35,6 +35,12 @@ public class SimpleQueryBuilderFactory implements SenseiQueryBuilderFactory
   }
 
   @Override
+  public SenseiQueryBuilder getQueryBuilder(SenseiQuery query)
+      throws Exception {
+    return new SimpleQueryBuilder(query, _parser);
+  }
+
+  @Override
   public SenseiQueryBuilder getQueryBuilder(SenseiQuery query, Searchable searchable) throws Exception {
     return new SimpleQueryBuilder(query, _parser);
   }


### PR DESCRIPTION
This Api was removed from the earlier commit causing backwards incompatibility. To fix the issue we are adding the Api back. 
